### PR TITLE
Fix VarInts writing integers as longs

### DIFF
--- a/common/src/main/java/com/nukkitx/network/VarInts.java
+++ b/common/src/main/java/com/nukkitx/network/VarInts.java
@@ -51,6 +51,18 @@ public class VarInts {
         throw new ArithmeticException("Varint was too large");
     }
 
+    private static void encodeUnsigned(ByteBuf buffer, int value) {
+        while (true) {
+            if ((value & ~0x7FL) == 0) {
+                buffer.writeByte((int) value);
+                return;
+            } else {
+                buffer.writeByte((byte) (((int) value & 0x7F) | 0x80));
+                value >>>= 7;
+            }
+        }
+    }
+
     private static void encodeUnsigned(ByteBuf buffer, long value) {
         while (true) {
             if ((value & ~0x7FL) == 0) {


### PR DESCRIPTION
Presently when writing an integer it is encoded as a long and uses up twice the amount of space in a packet. This also causes some issues when the receiver is expecting an int.

Noticed this when checking that raw packets through ProxyPass matched exactly when entering and exiting the system and all VarInts had an extra 4 bytes of '0xff' appended.

