### PR TITLE
Several improvements

### DIFF
--- a/raknet/src/main/java/com/nukkitx/network/raknet/RakNet.java
+++ b/raknet/src/main/java/com/nukkitx/network/raknet/RakNet.java
@@ -56,6 +56,10 @@ public abstract class RakNet implements AutoCloseable {
     }
 
     public void close() {
+        this.close(false);
+    }
+
+    public void close(boolean force) {
         this.closed.set(true);
         if (this.tickFuture != null) {
             this.tickFuture.cancel(false);

--- a/raknet/src/main/java/com/nukkitx/network/raknet/RakNet.java
+++ b/raknet/src/main/java/com/nukkitx/network/raknet/RakNet.java
@@ -21,7 +21,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 @ParametersAreNonnullByDefault
 public abstract class RakNet implements AutoCloseable {
-    protected final InetSocketAddress bindAddress;
     protected final long guid = ThreadLocalRandom.current().nextLong();
     protected final Bootstrap bootstrap;
     private final AtomicBoolean running = new AtomicBoolean(false);
@@ -29,9 +28,7 @@ public abstract class RakNet implements AutoCloseable {
     protected int protocolVersion = RakNetConstants.RAKNET_PROTOCOL_VERSION;
     protected final AtomicBoolean closed = new AtomicBoolean(false);
 
-    RakNet(InetSocketAddress bindAddress, EventLoopGroup eventLoopGroup) {
-        this.bindAddress = bindAddress;
-
+    RakNet(EventLoopGroup eventLoopGroup) {
         this.bootstrap = new Bootstrap().option(ChannelOption.ALLOCATOR, ByteBufAllocator.DEFAULT);
         this.bootstrap.group(eventLoopGroup);
         Bootstraps.setupBootstrap(this.bootstrap, true);
@@ -90,9 +87,7 @@ public abstract class RakNet implements AutoCloseable {
         this.protocolVersion = protocolVersion;
     }
 
-    public InetSocketAddress getBindAddress() {
-        return this.bindAddress;
-    }
+    public abstract InetSocketAddress getBindAddress();
 
     public long getGuid() {
         return this.guid;

--- a/raknet/src/main/java/com/nukkitx/network/raknet/RakNet.java
+++ b/raknet/src/main/java/com/nukkitx/network/raknet/RakNet.java
@@ -21,21 +21,20 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 @ParametersAreNonnullByDefault
 public abstract class RakNet implements AutoCloseable {
-    final long guid = ThreadLocalRandom.current().nextLong();
-    final Bootstrap bootstrap;
-    final InetSocketAddress bindAddress;
+    protected final InetSocketAddress bindAddress;
+    protected final long guid = ThreadLocalRandom.current().nextLong();
+    protected final Bootstrap bootstrap;
     private final AtomicBoolean running = new AtomicBoolean(false);
     private ScheduledFuture<?> tickFuture;
-    int protocolVersion = RakNetConstants.RAKNET_PROTOCOL_VERSION;
-    private volatile boolean closed;
+    protected int protocolVersion = RakNetConstants.RAKNET_PROTOCOL_VERSION;
+    protected final AtomicBoolean closed = new AtomicBoolean(false);
 
     RakNet(InetSocketAddress bindAddress, EventLoopGroup eventLoopGroup) {
         this.bindAddress = bindAddress;
 
         this.bootstrap = new Bootstrap().option(ChannelOption.ALLOCATOR, ByteBufAllocator.DEFAULT);
-
-        Bootstraps.setupBootstrap(this.bootstrap, true);
         this.bootstrap.group(eventLoopGroup);
+        Bootstraps.setupBootstrap(this.bootstrap, true);
     }
 
     static void send(ChannelHandlerContext ctx, InetSocketAddress recipient, ByteBuf buffer) {
@@ -44,24 +43,23 @@ public abstract class RakNet implements AutoCloseable {
 
     public CompletableFuture<Void> bind() {
         Preconditions.checkState(this.running.compareAndSet(false, true), "RakNet has already been started");
-
-        CompletableFuture<Void> future = bindInternal();
+        CompletableFuture<Void> future = this.bindInternal();
 
         future.whenComplete((aVoid, throwable) -> {
             if (throwable != null) {
                 // Failed to start. Set running to false
                 this.running.compareAndSet(true, false);
-            } else {
-                this.closed = false;
-                this.tickFuture = this.getEventLoopGroup().next().scheduleAtFixedRate(this::onTick,
-                        0, 10, TimeUnit.MILLISECONDS);
+                return;
             }
+
+            this.closed.set(false);
+            this.tickFuture = this.getEventLoopGroup().next().scheduleAtFixedRate(this::onTick, 0, 10, TimeUnit.MILLISECONDS);
         });
         return future;
     }
 
     public void close() {
-        this.closed = true;
+        this.closed.set(true);
         if (this.tickFuture != null) {
             this.tickFuture.cancel(false);
         }
@@ -76,16 +74,16 @@ public abstract class RakNet implements AutoCloseable {
     }
 
     public boolean isClosed() {
-        return closed;
+        return this.closed.get();
     }
 
     public Bootstrap getBootstrap() {
-        return bootstrap;
+        return this.bootstrap;
     }
 
     @Nonnegative
     public int getProtocolVersion() {
-        return protocolVersion;
+        return this.protocolVersion;
     }
 
     public void setProtocolVersion(@Nonnegative int protocolVersion) {
@@ -93,11 +91,11 @@ public abstract class RakNet implements AutoCloseable {
     }
 
     public InetSocketAddress getBindAddress() {
-        return bindAddress;
+        return this.bindAddress;
     }
 
     public long getGuid() {
-        return guid;
+        return this.guid;
     }
 
     protected EventLoopGroup getEventLoopGroup() {

--- a/raknet/src/main/java/com/nukkitx/network/raknet/RakNetClient.java
+++ b/raknet/src/main/java/com/nukkitx/network/raknet/RakNetClient.java
@@ -156,14 +156,15 @@ public class RakNetClient extends RakNet {
     }
 
     @Override
-    public void close() {
-        super.close();
+    public void close(boolean force) {
+        super.close(force);
         if (this.session != null && !this.session.isClosed()) {
             this.session.close();
         }
 
         if (this.channel != null) {
-            this.channel.close().syncUninterruptibly();
+            ChannelFuture future = this.channel.close();
+            if (force) future.syncUninterruptibly();
         }
     }
 

--- a/raknet/src/main/java/com/nukkitx/network/raknet/RakNetClient.java
+++ b/raknet/src/main/java/com/nukkitx/network/raknet/RakNetClient.java
@@ -36,7 +36,7 @@ public class RakNetClient extends RakNet {
 
     public RakNetClient(InetSocketAddress bindAddress, EventLoopGroup eventLoopGroup) {
         super(bindAddress, eventLoopGroup);
-        exceptionHandlers.put("DEFAULT", (t) -> log.error("An exception occurred in RakNet (Client)", t));
+        this.exceptionHandlers.put("DEFAULT", (t) -> log.error("An exception occurred in RakNet (Client)", t));
     }
 
     @Override
@@ -93,12 +93,16 @@ public class RakNetClient extends RakNet {
         this.exceptionHandlers.put(handlerId, handler);
     }
 
+    public void removeExceptionHandler(String handlerId) {
+        this.exceptionHandlers.remove(handlerId);
+    }
+
     public void clearExceptionHandlers() {
         this.exceptionHandlers.clear();
     }
 
-    public void removeExceptionHandler(String handlerId) {
-        this.exceptionHandlers.remove(handlerId);
+    public Collection<Consumer<Throwable>> getExceptionHandlers() {
+        return this.exceptionHandlers.values();
     }
 
     @Override
@@ -216,7 +220,7 @@ public class RakNetClient extends RakNet {
 
         @Override
         public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-            for (Consumer<Throwable> handler : RakNetClient.this.exceptionHandlers.values()) {
+            for (Consumer<Throwable> handler : RakNetClient.this.getExceptionHandlers()) {
                 handler.accept(cause);
             }
         }

--- a/raknet/src/main/java/com/nukkitx/network/raknet/RakNetClient.java
+++ b/raknet/src/main/java/com/nukkitx/network/raknet/RakNetClient.java
@@ -158,9 +158,12 @@ public class RakNetClient extends RakNet {
     @Override
     public void close() {
         super.close();
+        if (this.session != null && !this.session.isClosed()) {
+            this.session.close();
+        }
 
-        if (channel != null) {
-            channel.close().syncUninterruptibly();
+        if (this.channel != null) {
+            this.channel.close().syncUninterruptibly();
         }
     }
 

--- a/raknet/src/main/java/com/nukkitx/network/raknet/RakNetServer.java
+++ b/raknet/src/main/java/com/nukkitx/network/raknet/RakNetServer.java
@@ -34,6 +34,7 @@ public class RakNetServer extends RakNet {
     private final Set<Channel> channels = new HashSet<>();
     private final Iterator<Channel> channelIterator = new RoundRobinIterator<>(channels);
     private volatile RakNetServerListener listener = null;
+    private final InetSocketAddress bindAddress;
     private final int bindThreads;
     private int maxConnections = 1024;
     private final Map<String, Consumer<Throwable>> exceptionHandlers = new HashMap<>();
@@ -47,8 +48,9 @@ public class RakNetServer extends RakNet {
     }
 
     public RakNetServer(InetSocketAddress bindAddress, int bindThreads, EventLoopGroup eventLoopGroup) {
-        super(bindAddress, eventLoopGroup);
+        super(eventLoopGroup);
         this.bindThreads = bindThreads;
+        this.bindAddress = bindAddress;
         this.exceptionHandlers.put("DEFAULT", (t) -> log.error("An exception occurred in RakNet (Server)", t));
     }
 
@@ -96,6 +98,11 @@ public class RakNetServer extends RakNet {
 
     public void setMaxConnections(@Nonnegative int maxConnections) {
         this.maxConnections = maxConnections;
+    }
+
+    @Override
+    public InetSocketAddress getBindAddress() {
+        return this.bindAddress;
     }
 
     public RakNetServerListener getListener() {

--- a/raknet/src/main/java/com/nukkitx/network/raknet/RakNetServer.java
+++ b/raknet/src/main/java/com/nukkitx/network/raknet/RakNetServer.java
@@ -118,8 +118,8 @@ public class RakNetServer extends RakNet {
     }
 
     @Override
-    public void close() {
-        super.close();
+    public void close(boolean force) {
+        super.close(force);
         for (RakNetServerSession session : this.sessionsByAddress.values()) {
             session.disconnect(DisconnectReason.SHUTTING_DOWN);
         }

--- a/raknet/src/main/java/com/nukkitx/network/raknet/RakNetSession.java
+++ b/raknet/src/main/java/com/nukkitx/network/raknet/RakNetSession.java
@@ -898,7 +898,7 @@ public abstract class RakNetSession implements SessionConnection<ByteBuf> {
     }
 
     public boolean isClosed() {
-        return this.closed != 0;
+        return closedUpdater.get(this) != 0;
     }
 
     public abstract RakNet getRakNet();

--- a/raknet/src/main/java/com/nukkitx/network/raknet/RakNetSession.java
+++ b/raknet/src/main/java/com/nukkitx/network/raknet/RakNetSession.java
@@ -588,7 +588,7 @@ public abstract class RakNetSession implements SessionConnection<ByteBuf> {
         this.state = RakNetState.UNCONNECTED;
         this.onClose();
         if (log.isTraceEnabled()) {
-            log.trace("RakNet Session ({} => {}) closed: {}", this.getRakNet().bindAddress, this.address, reason);
+            log.trace("RakNet Session ({} => {}) closed: {}", this.getRakNet().getBindAddress(), this.address, reason);
         }
 
         this.deinitialize();

--- a/raknet/src/main/java/com/nukkitx/network/raknet/RakNetSession.java
+++ b/raknet/src/main/java/com/nukkitx/network/raknet/RakNetSession.java
@@ -143,7 +143,6 @@ public abstract class RakNetSession implements SessionConnection<ByteBuf> {
                 packet.release();
             }
         }
-        this.initHeapWeights();
     }
 
     public InetSocketAddress getAddress() {


### PR DESCRIPTION
- Use atomic values to check if session or raknet is closed.
- Allow Netty to choose bind address of `RakNetClient ` on its own.
- Close `RakNetClientSession` when `RakNetClient ` is closed.
- And small stuff which doesnt change external behavior.