### PR TITLE
Add IOUring beta

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -19,6 +19,12 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>io.netty.incubator</groupId>
+            <artifactId>netty-incubator-transport-native-io_uring</artifactId>
+            <version>0.0.3.Final</version>
+            <classifier>linux-x86_64</classifier>
+        </dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
             <version>${netty.version}</version>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -22,6 +22,7 @@
             <groupId>io.netty.incubator</groupId>
             <artifactId>netty-incubator-transport-native-io_uring</artifactId>
             <version>0.0.5.Final</version>
+            <classifier>linux-x86_64</classifier>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -21,8 +21,7 @@
         <dependency>
             <groupId>io.netty.incubator</groupId>
             <artifactId>netty-incubator-transport-native-io_uring</artifactId>
-            <version>0.0.3.Final</version>
-            <classifier>linux-x86_64</classifier>
+            <version>0.0.5.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>network-parent</artifactId>
         <groupId>com.nukkitx.network</groupId>
-        <version>1.6.27-SNAPSHOT</version>
+        <version>1.6.28-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.nukkitx.network</groupId>
     <artifactId>network-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.6.27-SNAPSHOT</version>
+    <version>1.6.28-SNAPSHOT</version>
     <inceptionYear>2018</inceptionYear>
     <url>https://github.com/NukkitX/Network</url>
 

--- a/query/pom.xml
+++ b/query/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>network-parent</artifactId>
         <groupId>com.nukkitx.network</groupId>
-        <version>1.6.27-SNAPSHOT</version>
+        <version>1.6.28-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/raknet/pom.xml
+++ b/raknet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>network-parent</artifactId>
         <groupId>com.nukkitx.network</groupId>
-        <version>1.6.27-SNAPSHOT</version>
+        <version>1.6.28-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rcon/pom.xml
+++ b/rcon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>network-parent</artifactId>
         <groupId>com.nukkitx.network</groupId>
-        <version>1.6.27-SNAPSHOT</version>
+        <version>1.6.28-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Hello, I thought it would be cool to add the newborn event loop to the list. The goal of this PR is to add IoUring for those who have the spec to enable it. I also add system properties to enable it since it's an incubator of netty which means it's always in beta. If you want to know more about this, here some link:
[https://blogs.oracle.com/linux/an-introduction-to-the-io_uring-asynchronous-io-framework](url)
[https://github.com/netty/netty-incubator-transport-io_uring](url)

Actually, it requires to have:
- an x86 or x64 processor
- at least kernel 5.9 of Linux
- And increase the default memlock

For the moment I add it to my own fork of geyser and use it in prod with 20-30 bedrock player on it, I also have a custom Velocity fork with their IoUring impl with 200 players and no problem. Some tests may be performed on Nukkit and other projects that use it to see if there is no problem, but since I don't use it, I can't.