### PR TITLE
Prevents Stale Datagrams from exhausting server memory

### DIFF
--- a/raknet/src/main/java/com/nukkitx/network/raknet/RakNetConstants.java
+++ b/raknet/src/main/java/com/nukkitx/network/raknet/RakNetConstants.java
@@ -38,6 +38,11 @@ public class RakNetConstants {
      * Time in millis after unconnected ping is resent till pong is not received.
      */
     public static final int RAKNET_PING_INTERVAL = 1000;
+    /**
+     * How many Stale Datagrams a {@link RakNetSession} can hold before been
+     * forcefully closed
+     */
+    public static final int MAXIMUM_STALE_DATAGRAMS = 256;
 
     /*
         Flags

--- a/raknet/src/main/java/com/nukkitx/network/raknet/RakNetSession.java
+++ b/raknet/src/main/java/com/nukkitx/network/raknet/RakNetSession.java
@@ -476,10 +476,11 @@ public abstract class RakNetSession implements SessionConnection<ByteBuf> {
         }
 
         // Send packets that are stale first. This function returns whether or not to continue
-        // send the rest of the datagram, as it might close the client due to too many stale packets
+        // send the rest of the datagrams, as it might close the client due to too many stale packets
         if (!this.sendStaleDatagrams(curTime)) {
             return;
         }
+
         // Now send usual packets
         this.sendDatagrams(curTime);
         // Finally flush channel

--- a/raknet/src/main/java/com/nukkitx/network/raknet/RakNetSession.java
+++ b/raknet/src/main/java/com/nukkitx/network/raknet/RakNetSession.java
@@ -531,13 +531,6 @@ public abstract class RakNetSession implements SessionConnection<ByteBuf> {
         if (this.sentDatagrams.isEmpty()) {
             return true;
         }
-        if (this.sentDatagrams.size() > MAXIMUM_STALE_DATAGRAMS) {
-            this.close(DisconnectReason.TIMED_OUT);
-            if (log.isTraceEnabled()) {
-                log.trace("Too many Slate datagrams for {}. Disconnected", this.address);
-            }
-            return false;
-        }
 
         boolean hasResent = false;
         int resendCount = 0;
@@ -557,6 +550,14 @@ public abstract class RakNetSession implements SessionConnection<ByteBuf> {
                 resendCount++;
                 this.sendDatagram(datagram, curTime);
             }
+        }
+
+        if (resendCount > MAXIMUM_STALE_DATAGRAMS) {
+            this.close(DisconnectReason.TIMED_OUT);
+            if (log.isTraceEnabled()) {
+                log.trace("Too many Slate datagrams for {}. Disconnected", this.address);
+            }
+            return false;
         }
 
         if (hasResent) {


### PR DESCRIPTION
This path caps the maximum allowed Stale Datagrams a RakNetSession can hold to 256, the client must ACK received datagrams to stay within this limit, otherwise it will be disconnected.

As far as I can tell, before this patch, the client can stay connected without necessarily clear all the datagrams that it has received (`touch` can be called by `onDatagram` without calling `onAcknowledge`), which allows the client to slowly consumes all the memory of the server, causing crash and maybe DoS attack.