### PR TITLE
Problem in RakUtils.java Reflective setAccessible(true)

### DIFF
--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/util/RakUtils.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/util/RakUtils.java
@@ -32,6 +32,7 @@ public class RakUtils {
     static {
         try {
             Constructor<DefaultChannelPipeline> constructor = DefaultChannelPipeline.class.getDeclaredConstructor(Channel.class);
+            //This is problem
             constructor.setAccessible(true);
             DEFAULT_CHANNEL_PIPELINE_CONSTRUCTOR = constructor;
         } catch (NoSuchMethodException e) {


### PR DESCRIPTION
Error `java.lang.UnsupportedOperationException: Reflective setAccessible(true) disabled` when using the `RakUtils` class

While running my application that utilizes the CloudburstMC and Netty libraries, I encountered the following error:
```java
java.lang.UnsupportedOperationException: Reflective setAccessible(true) disabled
    at org.cloudburstmc.netty.util.RakUtils.<clinit>(RakUtils.java:28)
    ...
```
The error seems to be due to an attempt to access the private constructor of the `DefaultChannelPipeline` class from Netty using reflection. This occurs in the `RakUtils` class of the CloudburstMC library.

Steps to Reproduce:
1. Integrate the CloudburstMC library into a project.
2. Try to execute a feature that uses the RakUtils class.

Relevant Code:
Snippet from the `RakUtils` class:

```java
static {
    try {
        Constructor<DefaultChannelPipeline> constructor = DefaultChannelPipeline.class.getDeclaredConstructor(Channel.class);
        constructor.setAccessible(true);
        DEFAULT_CHANNEL_PIPELINE_CONSTRUCTOR = constructor;
    } catch (NoSuchMethodException e) {
        throw new AssertionError("Unable to find DefaultChannelPipeline(Channel) constructor", e);
    }
}
```
Environment:
Operating System: Windows, Linux, Debian
Java Version: 17
CloudburstMC Library Version: latest
Netty Version: latest

I am willing to provide additional information or conduct tests to resolve this issue.

Thank you !


