### PR TITLE
Add IpDontFragmentProvider#isIpDontFragmentSupported

### DIFF
--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/util/IpDontFragmentProvider.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/util/IpDontFragmentProvider.java
@@ -44,9 +44,13 @@ public class IpDontFragmentProvider {
         IP_DONT_FRAGMENT_FALSE_VALUE = ipDontFragmentFalseValue;
     }
 
+    public static boolean isIpDontFragmentSupported() {
+        return IP_DONT_FRAGMENT_OPTION != null;
+    }
+
     @SuppressWarnings("unchecked")
     public static <T> boolean trySet(Channel channel, boolean value) {
-        if (IP_DONT_FRAGMENT_OPTION == null) return false;
+        if (!isIpDontFragmentSupported()) return false;
         boolean success = channel.config().setOption((ChannelOption<T>) IP_DONT_FRAGMENT_OPTION, (T) (value ? IP_DONT_FRAGMENT_TRUE_VALUE : IP_DONT_FRAGMENT_FALSE_VALUE));
         return success ? value : !value;
     }


### PR DESCRIPTION
Adds a method to query if the IP Don't Fragment flag is supported. Useful to conditionally set the flag to prevent netty spamming the logs with warnings if the flag is set, but not supported