### PR TITLE
Add ability to set time between connection attempts

### DIFF
--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakConstants.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakConstants.java
@@ -43,6 +43,8 @@ public class RakConstants {
     public static final int RAKNET_DATAGRAM_HEADER_SIZE = 4;
 
     public static final int MAXIMUM_CONNECTION_ATTEMPTS = 10;
+
+    public static final int TIME_BETWEEN_SEND_CONNECTION_ATTEMPTS_MS = 1000;
     /**
      * Time after {@link RakSessionCodec} is closed due to no activity.
      */

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/DefaultRakClientConfig.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/DefaultRakClientConfig.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import static org.cloudburstmc.netty.channel.raknet.RakConstants.DEFAULT_UNCONNECTED_MAGIC;
 import static org.cloudburstmc.netty.channel.raknet.RakConstants.MTU_SIZES;
 import static org.cloudburstmc.netty.channel.raknet.RakConstants.SESSION_TIMEOUT_MS;
+import static org.cloudburstmc.netty.channel.raknet.RakConstants.TIME_BETWEEN_SEND_CONNECTION_ATTEMPTS_MS;
 
 /**
  * The extended implementation of {@link RakChannelConfig} based on {@link DefaultRakSessionConfig} used by client.
@@ -41,6 +42,7 @@ public class DefaultRakClientConfig extends DefaultRakSessionConfig {
     private volatile Integer[] mtuSizes = MTU_SIZES;
     private volatile boolean ipDontFragment = false;
     private volatile int clientInternalAddresses = 10;
+    private volatile int timeBetweenSendConnectionAttemptsMS = TIME_BETWEEN_SEND_CONNECTION_ATTEMPTS_MS;
 
     public DefaultRakClientConfig(Channel channel) {
         super(channel);
@@ -51,7 +53,7 @@ public class DefaultRakClientConfig extends DefaultRakSessionConfig {
         return this.getOptions(
             super.getOptions(), 
             RakChannelOption.RAK_UNCONNECTED_MAGIC, RakChannelOption.RAK_CONNECT_TIMEOUT, RakChannelOption.RAK_REMOTE_GUID, RakChannelOption.RAK_SESSION_TIMEOUT, RakChannelOption.RAK_COMPATIBILITY_MODE,
-            RakChannelOption.RAK_MTU_SIZES, RakChannelOption.RAK_IP_DONT_FRAGMENT, RakChannelOption.RAK_CLIENT_INTERNAL_ADDRESSES);
+            RakChannelOption.RAK_MTU_SIZES, RakChannelOption.RAK_IP_DONT_FRAGMENT, RakChannelOption.RAK_CLIENT_INTERNAL_ADDRESSES, RakChannelOption.RAK_TIME_BETWEEN_SEND_CONNECTION_ATTEMPTS_MS);
     }
 
     @SuppressWarnings("unchecked")
@@ -73,6 +75,8 @@ public class DefaultRakClientConfig extends DefaultRakSessionConfig {
             return (T) Boolean.valueOf(this.ipDontFragment);
         } else if (option == RakChannelOption.RAK_CLIENT_INTERNAL_ADDRESSES) {
             return (T) Integer.valueOf(this.clientInternalAddresses);
+        } else if (option == RakChannelOption.RAK_TIME_BETWEEN_SEND_CONNECTION_ATTEMPTS_MS) {
+            return (T) Integer.valueOf(this.timeBetweenSendConnectionAttemptsMS);
         }
         return super.getOption(option);
     }
@@ -104,6 +108,9 @@ public class DefaultRakClientConfig extends DefaultRakSessionConfig {
             return (Boolean) value == this.isIpDontFragment();
         } else if (option == RakChannelOption.RAK_CLIENT_INTERNAL_ADDRESSES) {
             this.setClientInternalAddresses((Integer) value);
+            return true;
+        } else if (option == RakChannelOption.RAK_TIME_BETWEEN_SEND_CONNECTION_ATTEMPTS_MS) {
+            this.setTimeBetweenSendConnectionAttemptsMS((Integer) value);
             return true;
         }
         return super.setOption(option, value);
@@ -180,5 +187,13 @@ public class DefaultRakClientConfig extends DefaultRakSessionConfig {
 
     public void setClientInternalAddresses(int clientInternalAddresses) {
         this.clientInternalAddresses = clientInternalAddresses;
+    }
+
+    public int getTimeBetweenSendConnectionAttemptsMS() {
+        return this.timeBetweenSendConnectionAttemptsMS;
+    }
+
+    public void setTimeBetweenSendConnectionAttemptsMS(int timeBetweenSendConnectionAttemptsMS) {
+        this.timeBetweenSendConnectionAttemptsMS = timeBetweenSendConnectionAttemptsMS;
     }
 }

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/RakChannelOption.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/RakChannelOption.java
@@ -182,6 +182,13 @@ public class RakChannelOption<T> extends ChannelOption<T> {
     public static final ChannelOption<Integer> RAK_CLIENT_INTERNAL_ADDRESSES =
             valueOf(RakChannelOption.class, "RAK_CLIENT_INTERNAL_ADDRESSES");
 
+
+    /**
+     * The time between the client sending connection attempts in milliseconds.
+     */
+    public static final ChannelOption<Integer> RAK_TIME_BETWEEN_SEND_CONNECTION_ATTEMPTS_MS =
+            valueOf(RakChannelOption.class, "RAK_TIME_BETWEEN_SEND_CONNECTION_ATTEMPTS_MS");
+
     @SuppressWarnings("deprecation")
     protected RakChannelOption() {
         super(null);

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/client/RakClientOfflineHandler.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/client/RakClientOfflineHandler.java
@@ -57,7 +57,8 @@ public class RakClientOfflineHandler extends SimpleChannelInboundHandler<ByteBuf
         Channel channel = ctx.channel();
         long timeout = this.rakChannel.config().getOption(RakChannelOption.RAK_CONNECT_TIMEOUT);
         this.timeoutFuture = channel.eventLoop().schedule(this::onTimeout, timeout, TimeUnit.MILLISECONDS);
-        this.retryFuture = channel.eventLoop().scheduleAtFixedRate(() -> this.onRetryAttempt(channel), 0, 1, TimeUnit.SECONDS);
+        this.retryFuture = channel.eventLoop().scheduleAtFixedRate(() -> this.onRetryAttempt(channel), 0,
+            this.rakChannel.config().getOption(RakChannelOption.RAK_TIME_BETWEEN_SEND_CONNECTION_ATTEMPTS_MS), TimeUnit.MILLISECONDS);
         this.successPromise.addListener(future -> safeCancel(this.timeoutFuture, channel));
         this.successPromise.addListener(future -> safeCancel(this.retryFuture, channel));
 


### PR DESCRIPTION
The original RakNet allows setting the delay between connection attempts, which defaults to 1000ms. See:
- https://github.com/facebookarchive/RakNet/blob/master/Source/RakPeer.cpp#L5754
- https://github.com/facebookarchive/RakNet/blob/master/Source/RakPeer.h#L175

However, per testing in WireShark, the vanilla client uses 500ms. This PR adds a client channel option defaulting to 1000ms so that those wishing to more closely emulate the vanilla client can modify the value if needed.