### PR TITLE
Fix Issues with Offline State

### DIFF
--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/client/RakClientOfflineHandler.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/client/RakClientOfflineHandler.java
@@ -76,14 +76,21 @@ public class RakClientOfflineHandler extends SimpleChannelInboundHandler<ByteBuf
     }
 
     private void onRetryAttempt(Channel channel) {
-        switch (this.state) {
-            case HANDSHAKE_1:
+        if (this.rakChannel.config().getOption(RakChannelOption.RAK_COMPATIBILITY_MODE)) {
+            if (this.state != RakOfflineState.HANDSHAKE_COMPLETED) {
                 this.sendOpenConnectionRequest1(channel);
                 this.connectionAttempts++;
-                break;
-            case HANDSHAKE_2:
-                this.sendOpenConnectionRequest2(channel);
-                break;
+            }
+        } else {
+            switch (this.state) {
+                case HANDSHAKE_1:
+                    this.sendOpenConnectionRequest1(channel);
+                    this.connectionAttempts++;
+                    break;
+                case HANDSHAKE_2:
+                    this.sendOpenConnectionRequest2(channel);
+                    break;
+            }
         }
     }
 
@@ -158,6 +165,8 @@ public class RakClientOfflineHandler extends SimpleChannelInboundHandler<ByteBuf
         if (security) {
             this.cookie = buffer.readInt();
             this.security = true;
+        } else {
+            this.security = false;
         }
         int mtu = buffer.readShort();
 


### PR DESCRIPTION
This PR fixes an issue with the security state not being updated. Some servers (e.g. Enchanted Dragons) send a cookie in their first `Open Connection Reply 1`, but later send another `Open Connection Reply 1` that omits the cookie. In such a case, we should also omit the cookie from our subsequent `Open Connection Request 2` responses.

Secondly, `RakClientOfflineHandler` currently re-sends either `Open Connection Request 1` or `Open Connection Request 2` depending on the handshake state. The Vanilla client, however, will only send `Open Connection Request 1` as a retry. `Open Request 2` is only sent as a direct response to `Open Connection Reply 1`. This PR brings the client inline with this behavior in compatibility mode. 