### PR TITLE
Count Max Queued Bytes Per Incoming/Outgoing Packet Instead of Looping Per Tick

### DIFF
--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/common/RakSessionCodec.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/common/RakSessionCodec.java
@@ -440,7 +440,7 @@ public class RakSessionCodec extends ChannelDuplexHandler {
 
         RakChannelMetrics metrics = this.getMetrics();
         if (metrics != null) {
-            metrics.queuedPacketBytes(this.queuedBytes);
+            metrics.queuedPacketBytes((int) this.queuedBytes);
         }
 
         if (this.state == RakState.UNCONNECTED) {

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/common/RakSessionCodec.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/common/RakSessionCodec.java
@@ -85,6 +85,8 @@ public class RakSessionCodec extends ChannelDuplexHandler {
     private Queue<IntRange> outgoingNaks;
     private long lastMinWeight;
 
+    private long queuedBytes = 0;
+
     public RakSessionCodec(RakChannel channel) {
         this.channel = channel;
         this.setState(RakState.UNCONNECTED);
@@ -175,6 +177,8 @@ public class RakSessionCodec extends ChannelDuplexHandler {
             }
             outgoingPackets.release();
         }
+
+        this.queuedBytes = 0;
 
         if (log.isTraceEnabled()) {
             log.trace("RakNet Session ({} => {}) closed!", this.channel.localAddress(), this.getRemoteAddress());
@@ -268,8 +272,12 @@ public class RakSessionCodec extends ChannelDuplexHandler {
         long weight = this.getNextWeight(message.priority());
         if (packets.length == 1) {
             this.outgoingPackets.insert(weight, packets[0]);
+            this.queuedBytes += packets[0].getBuffer().readableBytes();
         } else {
             this.outgoingPackets.insertSeries(weight, packets);
+            for (EncapsulatedPacket packet : packets) {
+                this.queuedBytes += packet.getBuffer().readableBytes();
+            }
         }
     }
 
@@ -425,22 +433,14 @@ public class RakSessionCodec extends ChannelDuplexHandler {
 
         int maxQueuedBytes = this.channel.config().getOption(RakChannelOption.RAK_MAX_QUEUED_BYTES);
 
-        if (maxQueuedBytes > 0) {
-            int queuedBytes = 0;
-            try {
-                for (EncapsulatedPacket packet : this.outgoingPackets) {
-                    queuedBytes += packet.getBuffer().readableBytes();
-                    if (queuedBytes > maxQueuedBytes) {
-                        this.disconnect(RakDisconnectReason.QUEUE_TOO_LONG);
-                        return;
-                    }
-                }
-            } finally {
-                RakChannelMetrics metrics = this.getMetrics();
-                if (metrics != null) {
-                    metrics.queuedPacketBytes(queuedBytes);
-                }
-            }
+        if (maxQueuedBytes > 0 && this.queuedBytes > maxQueuedBytes) {
+            this.disconnect(RakDisconnectReason.QUEUE_TOO_LONG);
+            return;
+        }
+
+        RakChannelMetrics metrics = this.getMetrics();
+        if (metrics != null) {
+            metrics.queuedPacketBytes(this.queuedBytes);
         }
 
         if (this.state == RakState.UNCONNECTED) {
@@ -617,6 +617,7 @@ public class RakSessionCodec extends ChannelDuplexHandler {
 
             transmissionBandwidth -= size;
             this.outgoingPackets.remove();
+            this.queuedBytes -= packet.getBuffer().readableBytes();
 
             // Send full datagram
             if (!datagram.tryAddPacket(packet, mtuSize)) {

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/common/RakSessionCodec.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/common/RakSessionCodec.java
@@ -85,7 +85,7 @@ public class RakSessionCodec extends ChannelDuplexHandler {
     private Queue<IntRange> outgoingNaks;
     private long lastMinWeight;
 
-    private long queuedBytes = 0;
+    private int queuedBytes = 0;
 
     public RakSessionCodec(RakChannel channel) {
         this.channel = channel;
@@ -440,7 +440,7 @@ public class RakSessionCodec extends ChannelDuplexHandler {
 
         RakChannelMetrics metrics = this.getMetrics();
         if (metrics != null) {
-            metrics.queuedPacketBytes((int) this.queuedBytes);
+            metrics.queuedPacketBytes(this.queuedBytes);
         }
 
         if (this.state == RakState.UNCONNECTED) {


### PR DESCRIPTION
We had a report of a Geyser server locking up multiple times per day, requiring restart. CPU and RAM usage was not excessive, and Bedrock players would generally time out. New Bedrock connections could not be established.

This thread dump was provided: [thread_dump.txt](https://github.com/user-attachments/files/24020049/thread_dump.txt).

I noticed the following:
```
"GeyserServer-2-1" #43 [72] daemon prio=5 os_prio=0 cpu=26283587.31ms elapsed=80454.57s tid=0x00007ff0a5871cf0 nid=72 runnable  [0x00007ff069d14000]
   java.lang.Thread.State: RUNNABLE
    at org.cloudburstmc.netty.handler.codec.raknet.common.RakSessionCodec.onTick(RakSessionCodec.java:437)
    at org.cloudburstmc.netty.handler.codec.raknet.common.RakSessionCodec.tryTick(RakSessionCodec.java:416)
    at org.cloudburstmc.netty.handler.codec.raknet.common.RakSessionCodec$$Lambda/0x00007ff0148147a0.run(Unknown Source)
    at io.netty.util.concurrent.PromiseTask.runTask(PromiseTask.java:98)
    at io.netty.util.concurrent.ScheduledFutureTask.run(ScheduledFutureTask.java:166)
    at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:148)
    at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:141)
    at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:535)
    at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:201)
    at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1193)
    at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
    at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
    at java.lang.Thread.runWith(java.base@21.0.9/Thread.java:1596)
    at java.lang.Thread.run(java.base@21.0.9/Thread.java:1583)
```

Roughly 1/3 of CPU time over the thread dump period was spent in this loop: https://github.com/CloudburstMC/Network/blob/e5ae18c36399dc693e15c6505e3f941e1c05207a/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/common/RakSessionCodec.java#L431-L437

Modifying `RakSessionCodec` to track this on an ongoing basis rather than in `onTick` seemed to resolve this issue for the server. I believe that this becomes more pronounced as the queue grows larger, since the loop takes longer and blocks packet send, which must occur to decrease the size of the outgoing queue.