### PR TITLE
Feature: Expose per-channel metrics optionally to server metrics

### DIFF
--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakChildChannel.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakChildChannel.java
@@ -18,6 +18,7 @@ package org.cloudburstmc.netty.channel.raknet;
 
 import io.netty.channel.*;
 import io.netty.util.ReferenceCountUtil;
+import org.cloudburstmc.netty.channel.raknet.config.DefaultChannelToServerProxyMetrics;
 import org.cloudburstmc.netty.channel.raknet.config.DefaultRakSessionConfig;
 import org.cloudburstmc.netty.channel.raknet.config.RakChannelConfig;
 import org.cloudburstmc.netty.handler.codec.raknet.common.*;
@@ -45,7 +46,7 @@ public class RakChildChannel extends AbstractChannel implements RakChannel {
         super(parent);
         this.remoteAddress = remoteAddress;
         this.localAddress = localAddress;
-        this.config = new DefaultRakSessionConfig(this);
+        this.config = new DefaultRakSessionConfig(this, new DefaultChannelToServerProxyMetrics(parent, this));
         this.config.setGuid(guid);
         this.config.setProtocolVersion(version);
         this.config.setMtu(mtu);

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/DefaultChannelToServerProxyMetrics.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/DefaultChannelToServerProxyMetrics.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 CloudburstMC
+ *
+ * CloudburstMC licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.cloudburstmc.netty.channel.raknet.config;
+
+import org.cloudburstmc.netty.channel.raknet.RakChildChannel;
+import org.cloudburstmc.netty.channel.raknet.RakServerChannel;
+import org.cloudburstmc.netty.channel.raknet.RakState;
+
+public class DefaultChannelToServerProxyMetrics implements RakChannelMetrics {
+    
+    public RakServerChannel parent;
+    public RakChildChannel channel;
+
+    public DefaultChannelToServerProxyMetrics(RakServerChannel parent, RakChildChannel channel) {
+        this.parent = parent;
+        this.channel = channel;
+    }
+
+    public void bytesIn(int count) {
+        this.parent.config().getMetrics().bytesIn(channel, count);
+    }
+
+    public void bytesOut(int count) {
+        this.parent.config().getMetrics().bytesOut(channel, count);
+    }
+
+    public void rakDatagramsIn(int count) {
+        this.parent.config().getMetrics().rakDatagramsIn(channel, count);
+    }
+
+    public void rakDatagramsOut(int count) {
+        this.parent.config().getMetrics().rakDatagramsOut(channel, count);
+    }
+
+    public void encapsulatedIn(int count) {
+        this.parent.config().getMetrics().encapsulatedIn(channel, count);
+    }
+
+    public void encapsulatedOut(int count) {
+        this.parent.config().getMetrics().encapsulatedOut(channel, count);
+    }
+
+    public void rakStaleDatagrams(int count) {
+        this.parent.config().getMetrics().rakStaleDatagrams(channel, count);
+    }
+
+    public void ackIn(int count) {
+        this.parent.config().getMetrics().ackIn(channel, count);
+    }
+
+    public void ackOut(int count) {
+        this.parent.config().getMetrics().ackOut(channel, count);
+    }
+
+    public void nackOut(int count) {
+        this.parent.config().getMetrics().nackOut(channel, count);
+    }
+
+    public void nackIn(int count) {
+        this.parent.config().getMetrics().nackIn(channel, count);
+    }
+
+    public void stateChange(RakState state) {
+        this.parent.config().getMetrics().stateChange(channel, state);
+    }
+
+    public void queuedPacketBytes(int count) {
+        this.parent.config().getMetrics().queuedPacketBytes(channel, count);
+    }
+}

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/DefaultRakSessionConfig.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/DefaultRakSessionConfig.java
@@ -44,6 +44,11 @@ public class DefaultRakSessionConfig extends DefaultChannelConfig implements Rak
         super(channel);
     }
 
+    public DefaultRakSessionConfig(Channel channel, RakChannelMetrics metrics) {
+        super(channel);
+        this.metrics = metrics;
+    }
+
     @Override
     public Map<ChannelOption<?>, Object> getOptions() {
         return this.getOptions(

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/RakServerMetrics.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/RakServerMetrics.java
@@ -16,6 +16,9 @@
 
 package org.cloudburstmc.netty.channel.raknet.config;
 
+import org.cloudburstmc.netty.channel.raknet.RakChildChannel;
+import org.cloudburstmc.netty.channel.raknet.RakState;
+
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 
@@ -37,5 +40,44 @@ public interface RakServerMetrics {
     }
 
     default void addressUnblocked(InetAddress address) {
+    }
+
+    default void bytesIn(RakChildChannel channel, int count) {
+    }
+
+    default void bytesOut(RakChildChannel channel, int count) {
+    }
+
+    default void rakDatagramsIn(RakChildChannel channel, int count) {
+    }
+
+    default void rakDatagramsOut(RakChildChannel channel, int count) {
+    }
+
+    default void encapsulatedIn(RakChildChannel channel, int count) {
+    }
+
+    default void encapsulatedOut(RakChildChannel channel, int count) {
+    }
+
+    default void rakStaleDatagrams(RakChildChannel channel, int count) {
+    }
+
+    default void ackIn(RakChildChannel channel, int count) {
+    }
+
+    default void ackOut(RakChildChannel channel, int count) {
+    }
+
+    default void nackOut(RakChildChannel channel, int count) {
+    }
+
+    default void nackIn(RakChildChannel channel, int count) {
+    }
+
+    default void stateChange(RakChildChannel channel, RakState state) {
+    }
+
+    default void queuedPacketBytes(RakChildChannel channel, int count) {
     }
 }


### PR DESCRIPTION
This is an attempt to expose channel metrics in the server metrics config in a non-breaking way so existing configs can work as before. Would be helpful in cases where setting an option per-channel is not desired / not simply feasible