### PR TITLE
Bump Netty version to 4.2.10.Final

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-netty = "4.1.101.Final"
+netty = "4.2.10.Final"
 junit = "5.9.2"
 
 


### PR DESCRIPTION
Update Gradle versions catalog to use Netty 4.2.10.Final (was 4.1.101.Final). This ensures projects referencing the catalog will resolve the newer Netty release.