### PR TITLE
Set Rak protocol version in offloaded cookie modes

### DIFF
--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/server/RakServerOfflineHandler.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/server/RakServerOfflineHandler.java
@@ -233,7 +233,9 @@ public class RakServerOfflineHandler extends AdvancedChannelInboundHandler<Datag
             return;
         }
 
-        if (mode == RakServerCookieMode.ACTIVE) {
+        if (mode == RakServerCookieMode.ACTIVE
+                || mode == RakServerCookieMode.OFFLOADED
+                || mode == RakServerCookieMode.OFFLOADED_PSK) {
             int protocolVersion = SipHash.getProtocolVersion(cookie);
             channel.config().setOption(RakChannelOption.RAK_PROTOCOL_VERSION, protocolVersion);
         }

--- a/transport-raknet/src/test/java/org/cloudburstmc/netty/RakCookieTests.java
+++ b/transport-raknet/src/test/java/org/cloudburstmc/netty/RakCookieTests.java
@@ -55,10 +55,12 @@ public class RakCookieTests {
 
     private EventLoopGroup group;
     private Channel serverChannel;
+    private BlockingQueue<Channel> acceptedChannels;
 
     @BeforeEach
     public void setup() {
         group = new NioEventLoopGroup();
+        acceptedChannels = new LinkedBlockingQueue<>();
     }
 
     @AfterEach
@@ -82,6 +84,7 @@ public class RakCookieTests {
                 .childHandler(new ChannelInitializer<Channel>() {
                     @Override
                     protected void initChannel(Channel ch) {
+                        acceptedChannels.add(ch);
                     }
                 });
 
@@ -174,6 +177,12 @@ public class RakCookieTests {
         ByteBuf content = response.content();
         Assertions.assertEquals(ID_OPEN_CONNECTION_REPLY_2, content.getUnsignedByte(0));
         response.release();
+        Channel accepted = acceptedChannels.poll(1, TimeUnit.SECONDS);
+        Assertions.assertNotNull(accepted, "Server should create a child channel in OFFLOADED mode");
+        Assertions.assertEquals(
+                PROTOCOL_VERSION,
+                accepted.config().getOption(RakChannelOption.RAK_PROTOCOL_VERSION),
+                "OFFLOADED mode should recover RakNet protocol version from the cookie");
         rawClient.close();
     }
 
@@ -212,6 +221,12 @@ public class RakCookieTests {
         Assertions.assertNotNull(response, "Server should respond to OCR2 with valid PSK cookie");
         Assertions.assertEquals(ID_OPEN_CONNECTION_REPLY_2, response.content().getUnsignedByte(0));
         response.release();
+        Channel accepted = acceptedChannels.poll(1, TimeUnit.SECONDS);
+        Assertions.assertNotNull(accepted, "Server should create a child channel in OFFLOADED_PSK mode");
+        Assertions.assertEquals(
+                PROTOCOL_VERSION,
+                accepted.config().getOption(RakChannelOption.RAK_PROTOCOL_VERSION),
+                "OFFLOADED_PSK mode should recover RakNet protocol version from the cookie");
         rawClient.close();
     }
 


### PR DESCRIPTION
## Summary
- recover `RAK_PROTOCOL_VERSION` from the cookie for `OFFLOADED` and `OFFLOADED_PSK` child channels
- keep `OFF` and `INVALID` unchanged, since those modes do not guarantee a meaningful cookie protocol nibble
- extend `RakCookieTests` to assert the accepted child channel inherits the expected RakNet protocol version in offloaded modes

## Why
Cloudburst already encodes the RakNet protocol version into the cookie nibble. In `ACTIVE` mode that version is copied onto the child channel, but `OFFLOADED` and `OFFLOADED_PSK` currently skip that step even after accepting the cookie.

That leaves downstream consumers that depend on `RAK_PROTOCOL_VERSION` with incomplete session state in offloaded deployments.

## Testing
- added regression assertions in `RakCookieTests` for `OFFLOADED` and `OFFLOADED_PSK`
