### PR TITLE
Fix protocol version race on child channel init

### DIFF
--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakServerChannel.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakServerChannel.java
@@ -26,6 +26,7 @@ import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.cloudburstmc.netty.channel.proxy.ProxyChannel;
 import org.cloudburstmc.netty.channel.raknet.config.DefaultRakServerConfig;
+import org.cloudburstmc.netty.channel.raknet.config.RakChannelOption;
 import org.cloudburstmc.netty.channel.raknet.config.RakServerChannelConfig;
 import org.cloudburstmc.netty.channel.raknet.config.RakServerCookieMode;
 import org.cloudburstmc.netty.handler.codec.raknet.common.UnconnectedPongEncoder;
@@ -75,13 +76,13 @@ public class RakServerChannel extends ProxyChannel<DatagramChannel> implements S
     /**
      * Create new child channel assigned to remote address.
      *
-     * @param address remote address of new connection.
-     * @return RakChildChannel instance of new channel.
+     * @param address         remote address of new connection.
+     * @param protocolVersion RakNet protocol version from the handshake cookie, or 0 if not available.
+     * @return RakChildChannel instance of new channel, or {@code null} if a non-replaceable channel already exists.
      */
-    public RakChildChannel createChildChannel(InetSocketAddress address, InetSocketAddress localAddress,
-                                              long clientGuid, int mtu) {
+    public RakChildChannel createChildChannel(InetSocketAddress address, InetSocketAddress localAddress, long clientGuid, int mtu, int protocolVersion) {
         RakChildChannel existingChannel = this.childChannelMap.get(address);
-        if (this.config().getCookieMode() != RakServerCookieMode.INVALID && 
+        if (this.config().getCookieMode() != RakServerCookieMode.INVALID &&
                 this.config().getCookieMode() != RakServerCookieMode.OFF && existingChannel != null) {
             // We know this player is coming from this IP address due to the cookie, so we can safely close the existing channel.
             existingChannel.close();
@@ -92,6 +93,10 @@ public class RakServerChannel extends ProxyChannel<DatagramChannel> implements S
 
         RakChildChannel channel = new RakChildChannel(address, localAddress, this, clientGuid, mtu, childConsumer);
         channel.closeFuture().addListener((GenericFutureListener<ChannelFuture>) this::onChildClosed);
+        // Set before fireChannelRead because initChannel runs async on the child worker thread.
+        if (protocolVersion != 0) {
+            channel.config().setOption(RakChannelOption.RAK_PROTOCOL_VERSION, protocolVersion);
+        }
         // Fire channel thought ServerBootstrap,
         // register to eventLoop, assign default options and attributes
         this.pipeline().fireChannelRead(channel).fireChannelReadComplete();

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/server/RakServerOfflineHandler.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/server/RakServerOfflineHandler.java
@@ -25,7 +25,6 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.cloudburstmc.netty.channel.raknet.RakChildChannel;
 import org.cloudburstmc.netty.channel.raknet.RakPing;
 import org.cloudburstmc.netty.channel.raknet.RakServerChannel;
-import org.cloudburstmc.netty.channel.raknet.config.RakChannelOption;
 import org.cloudburstmc.netty.channel.raknet.config.RakServerChannelConfig;
 import org.cloudburstmc.netty.channel.raknet.config.RakServerCookieMode;
 import org.cloudburstmc.netty.channel.raknet.config.RakServerMetrics;
@@ -201,7 +200,7 @@ public class RakServerOfflineHandler extends AdvancedChannelInboundHandler<Datag
                 // This is likely source IP spoofing so we will not reply
                 return;
             }
-                buffer.readBoolean(); // Client wrote challenge
+            buffer.readBoolean(); // Client wrote challenge
         }
 
         // TODO: Verify serverAddress matches?
@@ -221,8 +220,15 @@ public class RakServerOfflineHandler extends AdvancedChannelInboundHandler<Datag
             return;
         }
 
+        int protocolVersion = 0;
+        if (mode == RakServerCookieMode.ACTIVE
+                || mode == RakServerCookieMode.OFFLOADED
+                || mode == RakServerCookieMode.OFFLOADED_PSK) {
+            protocolVersion = SipHash.getProtocolVersion(cookie);
+        }
+
         RakServerChannel serverChannel = (RakServerChannel) ctx.channel();
-        RakChildChannel channel = serverChannel.createChildChannel(sender, packet.recipient(), clientGuid, mtu);
+        RakChildChannel channel = serverChannel.createChildChannel(sender, packet.recipient(), clientGuid, mtu, protocolVersion);
         if (channel == null) {
             if (log.isTraceEnabled()) {
                 log.trace("[{}] Received ID_OPEN_CONNECTION_REQUEST_2, but a channel already exists for this socket address",
@@ -231,13 +237,6 @@ public class RakServerOfflineHandler extends AdvancedChannelInboundHandler<Datag
             // Already connected
             this.sendAlreadyConnected(ctx, packet, magicBuf, guid);
             return;
-        }
-
-        if (mode == RakServerCookieMode.ACTIVE
-                || mode == RakServerCookieMode.OFFLOADED
-                || mode == RakServerCookieMode.OFFLOADED_PSK) {
-            int protocolVersion = SipHash.getProtocolVersion(cookie);
-            channel.config().setOption(RakChannelOption.RAK_PROTOCOL_VERSION, protocolVersion);
         }
 
         ByteBuf replyBuffer = ctx.alloc().ioBuffer(31);


### PR DESCRIPTION
`RAK_PROTOCOL_VERSION` was set on the child channel after `fireChannelRead`, which schedules `initChannel` asynchronously on the child worker thread. This caused a race where `initChannel` could read the default value of 0, throwing `"Unsupported RakNet protocol version: 0"`.