### PR TITLE
Add HAProxy handling

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@
 # under the License.
 #
 # We follow JBoss versioning https://developer.jboss.org/docs/DOC-10725
-version=1.0.0.CR3-SNAPSHOT
+version=1.1.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@
 # under the License.
 #
 # We follow JBoss versioning https://developer.jboss.org/docs/DOC-10725
-version=1.1.0-SNAPSHOT
+version=1.1.0.CR1-SNAPSHOT

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ junit = "5.9.2"
 netty-common = { group = "io.netty", name = "netty-common", version.ref = "netty" }
 netty-buffer = { group = "io.netty", name = "netty-buffer", version.ref = "netty" }
 netty-codec = { group = "io.netty", name = "netty-codec", version.ref = "netty" }
+netty-codec-haproxy = { group = "io.netty", name = "netty-codec-haproxy", version.ref = "netty" }
 netty-transport = { group = "io.netty", name = "netty-transport", version.ref = "netty" }
 netty-transport-native-unix-common = { group = "io.netty", name = "netty-transport-native-unix-common", version.ref = "netty" }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,7 +17,7 @@
 rootProject.name = "network"
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.4.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 include("transport-raknet")

--- a/transport-raknet/build.gradle.kts
+++ b/transport-raknet/build.gradle.kts
@@ -20,6 +20,7 @@ description = "RakNet transport for Netty"
 
 dependencies {
     api(libs.bundles.netty)
+    api(libs.netty.codec.haproxy)
     api(libs.expiringmap)
 
     testImplementation(libs.bundles.junit)

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/proxy/ProxyProtocolDecoder.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/proxy/ProxyProtocolDecoder.java
@@ -1,17 +1,26 @@
 /*
- * Copyright 2026 CloudburstMC
+ * Copyright (c) 2019-2023 GeyserMC. http://geysermc.org
  *
- * CloudburstMC licenses this file to you under the Apache License,
- * version 2.0 (the "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- *   https://www.apache.org/licenses/LICENSE-2.0
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
  */
 
 package org.cloudburstmc.netty.channel.proxy;

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/proxy/ProxyProtocolDecoder.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/proxy/ProxyProtocolDecoder.java
@@ -1,0 +1,595 @@
+/*
+ * Copyright 2026 CloudburstMC
+ *
+ * CloudburstMC licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.cloudburstmc.netty.channel.proxy;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.ProtocolDetectionResult;
+import io.netty.handler.codec.haproxy.*;
+import io.netty.util.ByteProcessor;
+import io.netty.util.CharsetUtil;
+
+import java.util.Objects;
+
+/**
+ * Decodes an HAProxy proxy protocol header
+ *
+ * @see <a href="https://haproxy.1wt.eu/download/1.5/doc/proxy-protocol.txt">Proxy Protocol Specification</a>
+ * @see <a href="https://github.com/netty/netty/blob/4.1/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoder.java">Netty implementation</a>
+ */
+public final class ProxyProtocolDecoder {
+    /**
+     * {@link ProtocolDetectionResult} for {@link HAProxyProtocolVersion#V1}.
+     */
+    private static final ProtocolDetectionResult<HAProxyProtocolVersion> DETECTION_RESULT_V1 =
+            ProtocolDetectionResult.detected(HAProxyProtocolVersion.V1);
+
+    /**
+     * {@link ProtocolDetectionResult} for {@link HAProxyProtocolVersion#V2}.
+     */
+    private static final ProtocolDetectionResult<HAProxyProtocolVersion> DETECTION_RESULT_V2 =
+            ProtocolDetectionResult.detected(HAProxyProtocolVersion.V2);
+
+    /**
+     * Used to extract a header frame out of the {@link ByteBuf} and return it.
+     */
+    private HeaderExtractor headerExtractor;
+
+    /**
+     * {@code true} if we're discarding input because we're already over maxLength
+     */
+    private boolean discarding;
+
+    /**
+     * Number of discarded bytes
+     */
+    private int discardedBytes;
+
+    /**
+     * {@code true} if we're finished decoding the proxy protocol header
+     */
+    private boolean finished;
+
+    /**
+     * Protocol specification version
+     */
+    private final int decodingVersion;
+
+    /**
+     * The latest v2 spec (2014/05/18) allows for additional data to be sent in the proxy protocol header beyond the
+     * address information block so now we need a configurable max header size
+     */
+    private final int v2MaxHeaderSize = 16 + 65535; // TODO: need to calculate max length if TLVs are desired.
+
+    private ProxyProtocolDecoder(int version) {
+        this.decodingVersion = version;
+    }
+
+    public static HAProxyMessage decode(ByteBuf packet, int version) {
+        if (version == -1) {
+            return null;
+        }
+        ProxyProtocolDecoder decoder = new ProxyProtocolDecoder(version);
+        return decoder.decodeHeader(packet);
+    }
+
+    private HAProxyMessage decodeHeader(ByteBuf in) {
+        final ByteBuf decoded = decodingVersion == 1 ? decodeLine(in) : decodeStruct(in);
+        if (decoded == null) {
+            return null;
+        }
+
+        finished = true;
+        try {
+            if (decodingVersion == 1) {
+                return decodeHeader(decoded.toString(CharsetUtil.US_ASCII));
+            } else {
+                return decodeHeader0(decoded);
+            }
+        } catch (HAProxyProtocolException e) {
+            throw fail(null, e);
+        }
+    }
+
+    /**
+     * Decodes a version 2, binary proxy protocol header. Copied from HAProxyMessage.
+     *
+     * @param header                     a version 2 proxy protocol header
+     * @return                           {@link HAProxyMessage} instance
+     * @throws HAProxyProtocolException  if any portion of the header is invalid
+     */
+    static HAProxyMessage decodeHeader0(ByteBuf header) {
+        Objects.requireNonNull(header, "header");
+
+        if (header.readableBytes() < 16) {
+            throw new HAProxyProtocolException(
+                    "incomplete header: " + header.readableBytes() + " bytes (expected: 16+ bytes)");
+        }
+
+        // Per spec, the 13th byte is the protocol version and command byte
+        header.skipBytes(12);
+        final byte verCmdByte = header.readByte();
+
+        HAProxyProtocolVersion ver;
+        try {
+            ver = HAProxyProtocolVersion.valueOf(verCmdByte);
+        } catch (IllegalArgumentException e) {
+            throw new HAProxyProtocolException(e);
+        }
+
+        if (ver != HAProxyProtocolVersion.V2) {
+            throw new HAProxyProtocolException("version 1 unsupported: 0x" + Integer.toHexString(verCmdByte));
+        }
+
+        HAProxyCommand cmd;
+        try {
+            cmd = HAProxyCommand.valueOf(verCmdByte);
+        } catch (IllegalArgumentException e) {
+            throw new HAProxyProtocolException(e);
+        }
+
+        if (cmd == HAProxyCommand.LOCAL) {
+            return unknownMsg(HAProxyProtocolVersion.V2, HAProxyCommand.LOCAL);
+        }
+
+        // Per spec, the 14th byte is the protocol and address family byte
+        HAProxyProxiedProtocol protAndFam;
+        try {
+            protAndFam = HAProxyProxiedProtocol.valueOf(header.readByte());
+        } catch (IllegalArgumentException e) {
+            throw new HAProxyProtocolException(e);
+        }
+
+        if (protAndFam == HAProxyProxiedProtocol.UNKNOWN) {
+            return unknownMsg(HAProxyProtocolVersion.V2, HAProxyCommand.PROXY);
+        }
+
+        int addressInfoLen = header.readUnsignedShort();
+
+        String srcAddress;
+        String dstAddress;
+        int addressLen;
+        int srcPort = 0;
+        int dstPort = 0;
+
+        HAProxyProxiedProtocol.AddressFamily addressFamily = protAndFam.addressFamily();
+
+        if (addressFamily == HAProxyProxiedProtocol.AddressFamily.AF_UNIX) {
+            // unix sockets require 216 bytes for address information
+            if (addressInfoLen < 216 || header.readableBytes() < 216) {
+                throw new HAProxyProtocolException(
+                        "incomplete UNIX socket address information: " +
+                                Math.min(addressInfoLen, header.readableBytes()) + " bytes (expected: 216+ bytes)");
+            }
+            int startIdx = header.readerIndex();
+            int addressEnd = header.forEachByte(startIdx, 108, ByteProcessor.FIND_NUL);
+            if (addressEnd == -1) {
+                addressLen = 108;
+            } else {
+                addressLen = addressEnd - startIdx;
+            }
+            srcAddress = header.toString(startIdx, addressLen, CharsetUtil.US_ASCII);
+
+            startIdx += 108;
+
+            addressEnd = header.forEachByte(startIdx, 108, ByteProcessor.FIND_NUL);
+            if (addressEnd == -1) {
+                addressLen = 108;
+            } else {
+                addressLen = addressEnd - startIdx;
+            }
+            dstAddress = header.toString(startIdx, addressLen, CharsetUtil.US_ASCII);
+            // AF_UNIX defines that exactly 108 bytes are reserved for the address. The previous methods
+            // did not increase the reader index although we already consumed the information.
+            header.readerIndex(startIdx + 108);
+        } else {
+            if (addressFamily == HAProxyProxiedProtocol.AddressFamily.AF_IPv4) {
+                // IPv4 requires 12 bytes for address information
+                if (addressInfoLen < 12 || header.readableBytes() < 12) {
+                    throw new HAProxyProtocolException(
+                            "incomplete IPv4 address information: " +
+                                    Math.min(addressInfoLen, header.readableBytes()) + " bytes (expected: 12+ bytes)");
+                }
+                addressLen = 4;
+            } else if (addressFamily == HAProxyProxiedProtocol.AddressFamily.AF_IPv6) {
+                // IPv6 requires 36 bytes for address information
+                if (addressInfoLen < 36 || header.readableBytes() < 36) {
+                    throw new HAProxyProtocolException(
+                            "incomplete IPv6 address information: " +
+                                    Math.min(addressInfoLen, header.readableBytes()) + " bytes (expected: 36+ bytes)");
+                }
+                addressLen = 16;
+            } else {
+                throw new HAProxyProtocolException(
+                        "unable to parse address information (unknown address family: " + addressFamily + ')');
+            }
+
+            // Per spec, the src address begins at the 17th byte
+            srcAddress = ipBytesToString(header, addressLen);
+            dstAddress = ipBytesToString(header, addressLen);
+            srcPort = header.readUnsignedShort();
+            dstPort = header.readUnsignedShort();
+        }
+
+        //noinspection StatementWithEmptyBody
+        while (skipNextTLV(header)) {
+        }
+        return new HAProxyMessage(ver, cmd, protAndFam, srcAddress, dstAddress, srcPort, dstPort);
+    }
+
+    /**
+     * Convert ip address bytes to string representation. From IPBytesToString
+     *
+     * @param header     buffer containing ip address bytes
+     * @param addressLen number of bytes to read (4 bytes for IPv4, 16 bytes for IPv6)
+     * @return           string representation of the ip address
+     */
+    private static String ipBytesToString(ByteBuf header, int addressLen) {
+        StringBuilder sb = new StringBuilder();
+        final int ipv4Len = 4;
+        final int ipv6Len = 8;
+        if (addressLen == ipv4Len) {
+            for (int i = 0; i < ipv4Len; i++) {
+                sb.append(header.readByte() & 0xff);
+                sb.append('.');
+            }
+        } else {
+            for (int i = 0; i < ipv6Len; i++) {
+                sb.append(Integer.toHexString(header.readUnsignedShort()));
+                sb.append(':');
+            }
+        }
+        sb.setLength(sb.length() - 1);
+        return sb.toString();
+    }
+
+    /**
+     * From HAProxyMessage
+     */
+    private static boolean skipNextTLV(final ByteBuf header) {
+        // We need at least 4 bytes for a TLV
+        if (header.readableBytes() < 4) {
+            return false;
+        }
+
+        header.skipBytes(1);
+        header.skipBytes(header.readUnsignedShort());
+        return true;
+    }
+
+    static HAProxyMessage decodeHeader(String header) {
+        if (header == null) {
+            throw new HAProxyProtocolException("header");
+        }
+
+        String[] parts = header.split(" ");
+        int numParts = parts.length;
+
+        if (numParts < 2) {
+            throw new HAProxyProtocolException(
+                    "invalid header: " + header + " (expected: 'PROXY' and proxied protocol values)");
+        }
+
+        if (!"PROXY".equals(parts[0])) {
+            throw new HAProxyProtocolException("unknown identifier: " + parts[0]);
+        }
+
+        HAProxyProxiedProtocol protAndFam;
+        try {
+            protAndFam = HAProxyProxiedProtocol.valueOf(parts[1]);
+        } catch (IllegalArgumentException e) {
+            throw new HAProxyProtocolException(e);
+        }
+
+        if (protAndFam != HAProxyProxiedProtocol.TCP4 &&
+                protAndFam != HAProxyProxiedProtocol.TCP6 &&
+                protAndFam != HAProxyProxiedProtocol.UNKNOWN) {
+            throw new HAProxyProtocolException("unsupported v1 proxied protocol: " + parts[1]);
+        }
+
+        if (protAndFam == HAProxyProxiedProtocol.UNKNOWN) {
+            return unknownMsg(HAProxyProtocolVersion.V1, HAProxyCommand.PROXY);
+        }
+
+        if (numParts != 6) {
+            throw new HAProxyProtocolException("invalid TCP4/6 header: " + header + " (expected: 6 parts)");
+        }
+
+        try {
+            return new HAProxyMessage(
+                    HAProxyProtocolVersion.V1, HAProxyCommand.PROXY,
+                    protAndFam, parts[2], parts[3], portStringToInt(parts[4]), portStringToInt(parts[5]));
+        } catch (RuntimeException e) {
+            throw new HAProxyProtocolException("invalid HAProxy message", e);
+        }
+    }
+
+    private static int portStringToInt(String value) {
+        int port;
+        try {
+            port = Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("invalid port: " + value, e);
+        }
+
+        if (port <= 0 || port > 65535) {
+            throw new IllegalArgumentException("invalid port: " + value + " (expected: 1 ~ 65535)");
+        }
+
+        return port;
+    }
+
+    /**
+     * Proxy protocol message for 'UNKNOWN' proxied protocols. Per spec, when the proxied protocol is
+     * 'UNKNOWN' we must discard all other header values.
+     */
+    private static HAProxyMessage unknownMsg(HAProxyProtocolVersion version, HAProxyCommand command) {
+        return new HAProxyMessage(version, command, HAProxyProxiedProtocol.UNKNOWN, null, null, 0, 0);
+    }
+
+    static final byte[] BINARY_PREFIX = {
+            (byte) 0x0D,
+            (byte) 0x0A,
+            (byte) 0x0D,
+            (byte) 0x0A,
+            (byte) 0x00,
+            (byte) 0x0D,
+            (byte) 0x0A,
+            (byte) 0x51,
+            (byte) 0x55,
+            (byte) 0x49,
+            (byte) 0x54,
+            (byte) 0x0A
+    };
+    static final int BINARY_PREFIX_LENGTH = BINARY_PREFIX.length;
+
+    public static int findVersion(final ByteBuf buffer) {
+        final int n = buffer.readableBytes();
+        // per spec, the version number is found in the 13th byte
+        if (n < 13) {
+            return -1;
+        }
+
+        int idx = buffer.readerIndex();
+        return match(BINARY_PREFIX, buffer, idx) ? buffer.getByte(idx + BINARY_PREFIX_LENGTH) : 1;
+    }
+
+    /**
+     * Create a frame out of the {@link ByteBuf} and return it.
+     *
+     * @param buffer  the {@link ByteBuf} from which to read data
+     * @return frame  the {@link ByteBuf} which represent the frame or {@code null} if no frame could
+     *                be created
+     */
+    private ByteBuf decodeStruct(ByteBuf buffer) {
+        if (headerExtractor == null) {
+            headerExtractor = new StructHeaderExtractor(v2MaxHeaderSize);
+        }
+        return headerExtractor.extract(buffer);
+    }
+
+    /**
+     * Create a frame out of the {@link ByteBuf} and return it.
+     *
+     * @param buffer  the {@link ByteBuf} from which to read data
+     * @return frame  the {@link ByteBuf} which represent the frame or {@code null} if no frame could
+     *                be created
+     */
+    private ByteBuf decodeLine(ByteBuf buffer) {
+        if (headerExtractor == null) {
+            headerExtractor = new LineHeaderExtractor(108);
+        }
+        return headerExtractor.extract(buffer);
+    }
+
+    private void failOverLimit(String length) {
+        int maxLength = decodingVersion == 1 ? 108 : v2MaxHeaderSize;
+        throw fail("header length (" + length + ") exceeds the allowed maximum (" + maxLength + ')', null);
+    }
+
+    private HAProxyProtocolException fail(String errMsg, Exception e) {
+        finished = true;
+        HAProxyProtocolException ppex;
+        if (errMsg != null && e != null) {
+            ppex = new HAProxyProtocolException(errMsg, e);
+        } else if (errMsg != null) {
+            ppex = new HAProxyProtocolException(errMsg);
+        } else if (e != null) {
+            ppex = new HAProxyProtocolException(e);
+        } else {
+            ppex = new HAProxyProtocolException();
+        }
+        return ppex;
+    }
+
+    static final byte[] TEXT_PREFIX = {
+            (byte) 'P',
+            (byte) 'R',
+            (byte) 'O',
+            (byte) 'X',
+            (byte) 'Y',
+    };
+
+    /**
+     * Returns the {@link ProtocolDetectionResult} for the given {@link ByteBuf}.
+     */
+    public static ProtocolDetectionResult<HAProxyProtocolVersion> detectProtocol(ByteBuf buffer) {
+        if (buffer.readableBytes() < 12) {
+            return ProtocolDetectionResult.needsMoreData();
+        }
+
+        int idx = buffer.readerIndex();
+
+        if (match(BINARY_PREFIX, buffer, idx)) {
+            return DETECTION_RESULT_V2;
+        }
+        if (match(TEXT_PREFIX, buffer, idx)) {
+            return DETECTION_RESULT_V1;
+        }
+        return ProtocolDetectionResult.invalid();
+    }
+
+    private static boolean match(byte[] prefix, ByteBuf buffer, int idx) {
+        for (int i = 0; i < prefix.length; i++) {
+            final byte b = buffer.getByte(idx + i);
+            if (b != prefix[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * HeaderExtractor create a header frame out of the {@link ByteBuf}.
+     */
+    private abstract class HeaderExtractor {
+        /** Header max size */
+        private final int maxHeaderSize;
+
+        protected HeaderExtractor(int maxHeaderSize) {
+            this.maxHeaderSize = maxHeaderSize;
+        }
+
+        /**
+         * Create a frame out of the {@link ByteBuf} and return it.
+         *
+         * @param buffer  the {@link ByteBuf} from which to read data
+         * @return frame  the {@link ByteBuf} which represent the frame or {@code null} if no frame could
+         *                be created
+         */
+        public ByteBuf extract(ByteBuf buffer) {
+            final int eoh = findEndOfHeader(buffer);
+            if (!discarding) {
+                if (eoh >= 0) {
+                    final int length = eoh - buffer.readerIndex();
+                    if (length > maxHeaderSize) {
+                        buffer.readerIndex(eoh + delimiterLength(buffer, eoh));
+                        failOverLimit(String.valueOf(length));
+                        return null;
+                    }
+                    ByteBuf frame = buffer.readSlice(length);
+                    buffer.skipBytes(delimiterLength(buffer, eoh));
+                    return frame;
+                } else {
+                    final int length = buffer.readableBytes();
+                    if (length > maxHeaderSize) {
+                        discardedBytes = length;
+                        buffer.skipBytes(length);
+                        discarding = true;
+                        failOverLimit("over " + discardedBytes);
+                    }
+                    return null;
+                }
+            } else {
+                if (eoh >= 0) {
+                    final int length = discardedBytes + eoh - buffer.readerIndex();
+                    buffer.readerIndex(eoh + delimiterLength(buffer, eoh));
+                    discardedBytes = 0;
+                    discarding = false;
+                    failOverLimit("over " + length);
+                } else {
+                    discardedBytes += buffer.readableBytes();
+                    buffer.skipBytes(buffer.readableBytes());
+                }
+                return null;
+            }
+        }
+
+        /**
+         * Find the end of the header from the given {@link ByteBuf}，the end may be a CRLF, or the length given by the
+         * header.
+         *
+         * @param buffer the buffer to be searched
+         * @return {@code -1} if can not find the end, otherwise return the buffer index of end
+         */
+        protected abstract int findEndOfHeader(ByteBuf buffer);
+
+        /**
+         * Get the length of the header delimiter.
+         *
+         * @param buffer the buffer where delimiter is located
+         * @param eoh index of delimiter
+         * @return length of the delimiter
+         */
+        protected abstract int delimiterLength(ByteBuf buffer, int eoh);
+    }
+
+    private final class LineHeaderExtractor extends HeaderExtractor {
+
+        LineHeaderExtractor(int maxHeaderSize) {
+            super(maxHeaderSize);
+        }
+
+        /**
+         * Returns the index in the buffer of the end of line found.
+         * Returns -1 if no end of line was found in the buffer.
+         */
+        @Override
+        protected int findEndOfHeader(ByteBuf buffer) {
+            final int n = buffer.writerIndex();
+            for (int i = buffer.readerIndex(); i < n; i++) {
+                final byte b = buffer.getByte(i);
+                if (b == '\r' && i < n - 1 && buffer.getByte(i + 1) == '\n') {
+                    return i;  // \r\n
+                }
+            }
+            return -1;  // Not found.
+        }
+
+        @Override
+        protected int delimiterLength(ByteBuf buffer, int eoh) {
+            return buffer.getByte(eoh) == '\r' ? 2 : 1;
+        }
+    }
+
+    private final class StructHeaderExtractor extends HeaderExtractor {
+
+        StructHeaderExtractor(int maxHeaderSize) {
+            super(maxHeaderSize);
+        }
+
+        /**
+         * Returns the index in the buffer of the end of header if found.
+         * Returns -1 if no end of header was found in the buffer.
+         */
+        @Override
+        protected int findEndOfHeader(ByteBuf buffer) {
+            final int n = buffer.readableBytes();
+
+            // per spec, the 15th and 16th bytes contain the address length in bytes
+            if (n < 16) {
+                return -1;
+            }
+
+            int offset = buffer.readerIndex() + 14;
+
+            // the total header length will be a fixed 16 byte sequence + the dynamic address information block
+            int totalHeaderBytes = 16 + buffer.getUnsignedShort(offset);
+
+            // ensure we actually have the full header available
+            if (n >= totalHeaderBytes) {
+                return totalHeaderBytes;
+            } else {
+                return -1;
+            }
+        }
+
+        @Override
+        protected int delimiterLength(ByteBuf buffer, int eoh) {
+            return 0;
+        }
+    }
+}

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakChildChannel.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakChildChannel.java
@@ -38,14 +38,16 @@ public class RakChildChannel extends AbstractChannel implements RakChannel {
     private final RakChannelConfig config;
     private final InetSocketAddress remoteAddress;
     private final InetSocketAddress localAddress;
+    private final InetSocketAddress clientAddress;
     private final DefaultChannelPipeline rakPipeline;
     private volatile boolean open = true;
     private volatile boolean active;
 
-    RakChildChannel(InetSocketAddress remoteAddress, InetSocketAddress localAddress, RakServerChannel parent, long guid, int mtu, Consumer<RakChannel> childConsumer) {
+    RakChildChannel(InetSocketAddress remoteAddress, InetSocketAddress localAddress, InetSocketAddress clientAddress, RakServerChannel parent, long guid, int mtu, Consumer<RakChannel> childConsumer) {
         super(parent);
         this.remoteAddress = remoteAddress;
         this.localAddress = localAddress;
+        this.clientAddress = clientAddress;
         this.config = new DefaultRakSessionConfig(this, new DefaultChannelToServerProxyMetrics(parent, this));
         this.config.setGuid(guid);
         this.config.setMtu(mtu);
@@ -87,7 +89,7 @@ public class RakChildChannel extends AbstractChannel implements RakChannel {
 
     @Override
     public SocketAddress remoteAddress0() {
-        return this.remoteAddress;
+        return this.clientAddress;
     }
 
     @Override
@@ -98,6 +100,10 @@ public class RakChildChannel extends AbstractChannel implements RakChannel {
     @Override
     public InetSocketAddress remoteAddress() {
         return (InetSocketAddress) super.remoteAddress();
+    }
+
+    public InetSocketAddress remoteOrProxyAddress() {
+        return remoteAddress;
     }
 
     @Override

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakChildChannel.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakChildChannel.java
@@ -89,7 +89,7 @@ public class RakChildChannel extends AbstractChannel implements RakChannel {
 
     @Override
     public SocketAddress remoteAddress0() {
-        return this.remoteAddress;
+        return this.clientAddress;
     }
 
     @Override
@@ -102,8 +102,8 @@ public class RakChildChannel extends AbstractChannel implements RakChannel {
         return (InetSocketAddress) super.remoteAddress();
     }
 
-    public InetSocketAddress clientAddress() {
-        return clientAddress;
+    public InetSocketAddress remoteOrProxyAddress() {
+        return remoteAddress;
     }
 
     @Override

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakChildChannel.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakChildChannel.java
@@ -89,7 +89,7 @@ public class RakChildChannel extends AbstractChannel implements RakChannel {
 
     @Override
     public SocketAddress remoteAddress0() {
-        return this.clientAddress;
+        return this.remoteAddress;
     }
 
     @Override
@@ -102,8 +102,8 @@ public class RakChildChannel extends AbstractChannel implements RakChannel {
         return (InetSocketAddress) super.remoteAddress();
     }
 
-    public InetSocketAddress remoteOrProxyAddress() {
-        return remoteAddress;
+    public InetSocketAddress clientAddress() {
+        return clientAddress;
     }
 
     @Override

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakServerChannel.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakServerChannel.java
@@ -78,6 +78,9 @@ public class RakServerChannel extends ProxyChannel<DatagramChannel> implements S
     }
 
     protected void initPipeline() {
+        if (this.config().getProxyProtocol()) {
+            this.pipeline().addLast(RakProxyServerHandler.NAME, new RakProxyServerHandler(this));
+        }
         this.pipeline().addLast(UnconnectedPongEncoder.NAME, UnconnectedPongEncoder.INSTANCE);
         if (this.config().getPacketLimit() > 0) { // No point in enabling this.
             this.pipeline().addLast(RakServerRateLimiter.NAME, new RakServerRateLimiter(this));
@@ -85,9 +88,6 @@ public class RakServerChannel extends ProxyChannel<DatagramChannel> implements S
         this.pipeline().addLast(RakServerOfflineHandler.NAME, new RakServerOfflineHandler(this));
         this.pipeline().addLast(RakServerRouteHandler.NAME, new RakServerRouteHandler(this));
         this.pipeline().addLast(RakServerTailHandler.NAME, RakServerTailHandler.INSTANCE);
-        if (this.config().getProxyProtocol()) {
-            this.pipeline().addFirst(RakProxyServerHandler.NAME, new RakProxyServerHandler(this));
-        }
     }
 
     /**

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakServerChannel.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakServerChannel.java
@@ -24,12 +24,15 @@ import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.PromiseCombiner;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
+import net.jodah.expiringmap.ExpirationPolicy;
+import net.jodah.expiringmap.ExpiringMap;
 import org.cloudburstmc.netty.channel.proxy.ProxyChannel;
 import org.cloudburstmc.netty.channel.raknet.config.DefaultRakServerConfig;
 import org.cloudburstmc.netty.channel.raknet.config.RakChannelOption;
 import org.cloudburstmc.netty.channel.raknet.config.RakServerChannelConfig;
 import org.cloudburstmc.netty.channel.raknet.config.RakServerCookieMode;
 import org.cloudburstmc.netty.handler.codec.raknet.common.UnconnectedPongEncoder;
+import org.cloudburstmc.netty.handler.codec.raknet.server.RakProxyServerHandler;
 import org.cloudburstmc.netty.handler.codec.raknet.server.RakServerOfflineHandler;
 import org.cloudburstmc.netty.handler.codec.raknet.server.RakServerRateLimiter;
 import org.cloudburstmc.netty.handler.codec.raknet.server.RakServerRouteHandler;
@@ -51,6 +54,9 @@ public class RakServerChannel extends ProxyChannel<DatagramChannel> implements S
     private final RakServerChannelConfig config;
     private final Map<SocketAddress, RakChildChannel> childChannelMap = new ConcurrentHashMap<>();
     private final Consumer<RakChannel> childConsumer;
+    private final ExpiringMap<InetSocketAddress, InetSocketAddress> clientAddresses = ExpiringMap.builder()
+            .expiration(RakConstants.SESSION_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                .expirationPolicy(ExpirationPolicy.ACCESSED).build();
 
     public RakServerChannel(DatagramChannel channel) {
         this(channel, null);
@@ -79,6 +85,9 @@ public class RakServerChannel extends ProxyChannel<DatagramChannel> implements S
         this.pipeline().addLast(RakServerOfflineHandler.NAME, new RakServerOfflineHandler(this));
         this.pipeline().addLast(RakServerRouteHandler.NAME, new RakServerRouteHandler(this));
         this.pipeline().addLast(RakServerTailHandler.NAME, RakServerTailHandler.INSTANCE);
+        if (this.config().getProxyProtocol()) {
+            this.pipeline().addFirst(RakProxyServerHandler.NAME, new RakProxyServerHandler(this));
+        }
     }
 
     /**
@@ -99,7 +108,8 @@ public class RakServerChannel extends ProxyChannel<DatagramChannel> implements S
             return null;
         }
 
-        RakChildChannel channel = new RakChildChannel(address, localAddress, this, clientGuid, mtu, childConsumer);
+        InetSocketAddress clientAddress = this.getClientAddress(address);
+        RakChildChannel channel = new RakChildChannel(address, localAddress, clientAddress == null ? address : clientAddress, this, clientGuid, mtu, childConsumer);
         channel.closeFuture().addListener((GenericFutureListener<ChannelFuture>) this::onChildClosed);
         // Set before fireChannelRead because initChannel runs async on the child worker thread.
         if (protocolVersion != 0) {
@@ -160,5 +170,13 @@ public class RakServerChannel extends ProxyChannel<DatagramChannel> implements S
     @Override
     public RakServerChannelConfig config() {
         return this.config;
+    }
+
+    public InetSocketAddress getClientAddress(InetSocketAddress address) {
+        return this.clientAddresses.get(address);
+    }
+
+    public void setClientAddress(InetSocketAddress address, InetSocketAddress clientAddress) {
+        this.clientAddresses.put(address, clientAddress);
     }
 }

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakServerChannel.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakServerChannel.java
@@ -55,10 +55,10 @@ public class RakServerChannel extends ProxyChannel<DatagramChannel> implements S
     private final RakServerChannelConfig config;
     private final Map<SocketAddress, RakChildChannel> childChannelMap = new ConcurrentHashMap<>();
     private final Consumer<RakChannel> childConsumer;
-    private final ExpiringMap<InetSocketAddress, InetSocketAddress> clientAddresses = ExpiringMap.builder()
-            .expiration(RakConstants.SESSION_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-            .expirationPolicy(ExpirationPolicy.ACCESSED).build();
-    private final Map<InetAddress, AtomicInteger> connectionsPerIp = new ConcurrentHashMap<>();
+
+    private final ExpiringMap<InetSocketAddress, InetSocketAddress> clientAddresses;
+    private final Map<InetAddress, AtomicInteger> connectionsPerIp;
+    private final ExpiringMap<InetAddress, AtomicInteger> connectionThrottle;
 
     public RakServerChannel(DatagramChannel channel) {
         this(channel, null);
@@ -69,6 +69,18 @@ public class RakServerChannel extends ProxyChannel<DatagramChannel> implements S
         this.childConsumer = childConsumer;
         this.config = new DefaultRakServerConfig(this);
         this.initPipeline();
+
+        this.clientAddresses = config().getProxyProtocol()
+                ? ExpiringMap.builder()
+                  .expiration(RakConstants.SESSION_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                  .expirationPolicy(ExpirationPolicy.ACCESSED).build()
+                : null;
+        this.connectionsPerIp = config().getMaxConnectionsPerIp() > 0 ? new ConcurrentHashMap<>() : null;
+        this.connectionThrottle = config().getConnectionThrottlePeriod() > 0 && config().getConnectionThrottleLimit() > 0
+                ? ExpiringMap.builder()
+                  .expiration(config().getConnectionThrottlePeriod(), TimeUnit.MILLISECONDS)
+                  .expirationPolicy(ExpirationPolicy.CREATED).build()
+                : null;
 
         channel.closeFuture().addListener(future -> {
             if (!future.isSuccess()) {
@@ -111,13 +123,23 @@ public class RakServerChannel extends ProxyChannel<DatagramChannel> implements S
         }
 
         InetSocketAddress clientAddress = this.getClientAddress(address);
-        int maxConnectionsPerIp = this.config().getMaxConnectionsPerIp();
-        if (maxConnectionsPerIp > 0) {
+
+        if (this.connectionsPerIp != null) {
             AtomicInteger connectionsPerIp = this.connectionsPerIp.computeIfAbsent(clientAddress.getAddress(), ignored -> new AtomicInteger());
-            if (connectionsPerIp.incrementAndGet() > maxConnectionsPerIp) {
-                connectionsPerIp.decrementAndGet();
+            if (connectionsPerIp.get() >= this.config().getMaxConnectionsPerIp()) {
                 return null;
             }
+
+            connectionsPerIp.incrementAndGet();
+        }
+
+        if (this.connectionThrottle != null) {
+            AtomicInteger connectionThrottleCount = this.connectionThrottle.computeIfAbsent(clientAddress.getAddress(), ignored -> new AtomicInteger());
+            if (connectionThrottleCount.get() >= this.config().getConnectionThrottleLimit()) {
+                return null;
+            }
+
+            connectionThrottleCount.incrementAndGet();
         }
 
         RakChildChannel channel = new RakChildChannel(address, localAddress, clientAddress, this, clientGuid, mtu, childConsumer);
@@ -156,9 +178,11 @@ public class RakServerChannel extends ProxyChannel<DatagramChannel> implements S
         // but the method is called on parent channel, and there is no other way to destroy pipeline.
         RakUtils.destroyChannelPipeline(channel.rakPipeline());
 
-        AtomicInteger connectionsPerIp = this.connectionsPerIp.get(channel.remoteAddress().getAddress());
-        if (connectionsPerIp != null && connectionsPerIp.decrementAndGet() <= 0) {
-            this.connectionsPerIp.remove(channel.remoteAddress().getAddress());
+        if (this.connectionsPerIp != null) {
+            AtomicInteger connectionsPerIp = this.connectionsPerIp.get(channel.remoteAddress().getAddress());
+            if (connectionsPerIp != null && connectionsPerIp.decrementAndGet() <= 0) {
+                this.connectionsPerIp.remove(channel.remoteAddress().getAddress());
+            }
         }
     }
 
@@ -189,8 +213,7 @@ public class RakServerChannel extends ProxyChannel<DatagramChannel> implements S
     }
 
     public InetSocketAddress getClientAddress(InetSocketAddress address) {
-        InetSocketAddress clientAddress = this.clientAddresses.get(address);
-        return clientAddress != null ? clientAddress : address;
+        return this.clientAddresses != null ? this.clientAddresses.get(address) : address;
     }
 
     public void setClientAddress(InetSocketAddress address, InetSocketAddress clientAddress) {

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakServerChannel.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakServerChannel.java
@@ -17,6 +17,7 @@
 package org.cloudburstmc.netty.channel.raknet;
 
 import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.socket.DatagramChannel;
@@ -39,13 +40,11 @@ import org.cloudburstmc.netty.handler.codec.raknet.server.RakServerRouteHandler;
 import org.cloudburstmc.netty.handler.codec.raknet.server.RakServerTailHandler;
 import org.cloudburstmc.netty.util.RakUtils;
 
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 public class RakServerChannel extends ProxyChannel<DatagramChannel> implements ServerChannel {
@@ -56,7 +55,8 @@ public class RakServerChannel extends ProxyChannel<DatagramChannel> implements S
     private final Map<SocketAddress, RakChildChannel> childChannelMap = new ConcurrentHashMap<>();
     private final Consumer<RakChannel> childConsumer;
 
-    private final ExpiringMap<InetSocketAddress, InetSocketAddress> clientAddresses;
+    private boolean pipelineInitialized;
+    private ExpiringMap<InetSocketAddress, InetSocketAddress> clientAddresses = null;
 
     public RakServerChannel(DatagramChannel channel) {
         this(channel, null);
@@ -66,13 +66,6 @@ public class RakServerChannel extends ProxyChannel<DatagramChannel> implements S
         super(channel);
         this.childConsumer = childConsumer;
         this.config = new DefaultRakServerConfig(this);
-        this.initPipeline();
-
-        this.clientAddresses = config().getProxyProtocol()
-                ? ExpiringMap.builder()
-                  .expiration(RakConstants.SESSION_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-                  .expirationPolicy(ExpirationPolicy.ACCESSED).build()
-                : null;
 
         channel.closeFuture().addListener(future -> {
             if (!future.isSuccess()) {
@@ -83,7 +76,21 @@ public class RakServerChannel extends ProxyChannel<DatagramChannel> implements S
         });
     }
 
+    @Override
+    public ChannelPipeline pipeline() {
+        if (!this.pipelineInitialized) {
+            this.pipelineInitialized = true;
+            initPipeline();
+        }
+        return super.pipeline();
+    }
+
     protected void initPipeline() {
+        this.clientAddresses = this.config().getProxyProtocol()
+                ? ExpiringMap.builder()
+                  .expiration(RakConstants.SESSION_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                  .expirationPolicy(ExpirationPolicy.ACCESSED).build()
+                : null;
         if (this.config().getProxyProtocol()) {
             this.pipeline().addLast(RakProxyServerHandler.NAME, new RakProxyServerHandler(this));
         }
@@ -131,7 +138,7 @@ public class RakServerChannel extends ProxyChannel<DatagramChannel> implements S
         this.childChannelMap.put(address, channel);
 
         if (this.config().getMetrics() != null) {
-            this.config().getMetrics().channelOpen(address);
+            this.config().getMetrics().channelOpen(clientAddress);
         }
         return channel;
     }
@@ -145,7 +152,7 @@ public class RakServerChannel extends ProxyChannel<DatagramChannel> implements S
         this.childChannelMap.remove(channel.remoteOrProxyAddress());
 
         if (this.config().getMetrics() != null) {
-            this.config().getMetrics().channelClose(channel.remoteOrProxyAddress());
+            this.config().getMetrics().channelClose(channel.remoteAddress());
         }
 
         channel.rakPipeline().fireChannelInactive();

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakServerChannel.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakServerChannel.java
@@ -57,8 +57,6 @@ public class RakServerChannel extends ProxyChannel<DatagramChannel> implements S
     private final Consumer<RakChannel> childConsumer;
 
     private final ExpiringMap<InetSocketAddress, InetSocketAddress> clientAddresses;
-    private final Map<InetAddress, AtomicInteger> connectionsPerIp;
-    private final ExpiringMap<InetAddress, AtomicInteger> connectionThrottle;
 
     public RakServerChannel(DatagramChannel channel) {
         this(channel, null);
@@ -74,12 +72,6 @@ public class RakServerChannel extends ProxyChannel<DatagramChannel> implements S
                 ? ExpiringMap.builder()
                   .expiration(RakConstants.SESSION_TIMEOUT_MS, TimeUnit.MILLISECONDS)
                   .expirationPolicy(ExpirationPolicy.ACCESSED).build()
-                : null;
-        this.connectionsPerIp = config().getMaxConnectionsPerIp() > 0 ? new ConcurrentHashMap<>() : null;
-        this.connectionThrottle = config().getConnectionThrottlePeriod() > 0 && config().getConnectionThrottleLimit() > 0
-                ? ExpiringMap.builder()
-                  .expiration(config().getConnectionThrottlePeriod(), TimeUnit.MILLISECONDS)
-                  .expirationPolicy(ExpirationPolicy.CREATED).build()
                 : null;
 
         channel.closeFuture().addListener(future -> {
@@ -123,23 +115,8 @@ public class RakServerChannel extends ProxyChannel<DatagramChannel> implements S
         }
 
         InetSocketAddress clientAddress = this.getClientAddress(address);
-
-        if (this.connectionsPerIp != null) {
-            AtomicInteger connectionsPerIp = this.connectionsPerIp.computeIfAbsent(clientAddress.getAddress(), ignored -> new AtomicInteger());
-            if (connectionsPerIp.get() >= this.config().getMaxConnectionsPerIp()) {
-                return null;
-            }
-
-            connectionsPerIp.incrementAndGet();
-        }
-
-        if (this.connectionThrottle != null) {
-            AtomicInteger connectionThrottleCount = this.connectionThrottle.computeIfAbsent(clientAddress.getAddress(), ignored -> new AtomicInteger());
-            if (connectionThrottleCount.get() >= this.config().getConnectionThrottleLimit()) {
-                return null;
-            }
-
-            connectionThrottleCount.incrementAndGet();
+        if (this.config().getThrottle() != null && !this.config().getThrottle().accept(clientAddress)) {
+            return null;
         }
 
         RakChildChannel channel = new RakChildChannel(address, localAddress, clientAddress, this, clientGuid, mtu, childConsumer);
@@ -178,11 +155,8 @@ public class RakServerChannel extends ProxyChannel<DatagramChannel> implements S
         // but the method is called on parent channel, and there is no other way to destroy pipeline.
         RakUtils.destroyChannelPipeline(channel.rakPipeline());
 
-        if (this.connectionsPerIp != null) {
-            AtomicInteger connectionsPerIp = this.connectionsPerIp.get(channel.remoteAddress().getAddress());
-            if (connectionsPerIp != null && connectionsPerIp.decrementAndGet() <= 0) {
-                this.connectionsPerIp.remove(channel.remoteAddress().getAddress());
-            }
+        if (this.config().getThrottle() != null) {
+            this.config().getThrottle().closed(channel.remoteAddress());
         }
     }
 

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakServerChannel.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakServerChannel.java
@@ -56,7 +56,7 @@ public class RakServerChannel extends ProxyChannel<DatagramChannel> implements S
     private final Consumer<RakChannel> childConsumer;
     private final ExpiringMap<InetSocketAddress, InetSocketAddress> clientAddresses = ExpiringMap.builder()
             .expiration(RakConstants.SESSION_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-                .expirationPolicy(ExpirationPolicy.ACCESSED).build();
+            .expirationPolicy(ExpirationPolicy.ACCESSED).build();
 
     public RakServerChannel(DatagramChannel channel) {
         this(channel, null);

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakServerChannel.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakServerChannel.java
@@ -109,7 +109,7 @@ public class RakServerChannel extends ProxyChannel<DatagramChannel> implements S
         }
 
         InetSocketAddress clientAddress = this.getClientAddress(address);
-        RakChildChannel channel = new RakChildChannel(address, localAddress, clientAddress == null ? address : clientAddress, this, clientGuid, mtu, childConsumer);
+        RakChildChannel channel = new RakChildChannel(address, localAddress, clientAddress, this, clientGuid, mtu, childConsumer);
         channel.closeFuture().addListener((GenericFutureListener<ChannelFuture>) this::onChildClosed);
         // Set before fireChannelRead because initChannel runs async on the child worker thread.
         if (protocolVersion != 0) {
@@ -132,10 +132,10 @@ public class RakServerChannel extends ProxyChannel<DatagramChannel> implements S
 
     private void onChildClosed(ChannelFuture channelFuture) {
         RakChildChannel channel = (RakChildChannel) channelFuture.channel();
-        this.childChannelMap.remove(channel.remoteAddress());
+        this.childChannelMap.remove(channel.remoteOrProxyAddress());
 
         if (this.config().getMetrics() != null) {
-            this.config().getMetrics().channelClose(channel.remoteAddress());
+            this.config().getMetrics().channelClose(channel.remoteOrProxyAddress());
         }
 
         channel.rakPipeline().fireChannelInactive();
@@ -173,7 +173,8 @@ public class RakServerChannel extends ProxyChannel<DatagramChannel> implements S
     }
 
     public InetSocketAddress getClientAddress(InetSocketAddress address) {
-        return this.clientAddresses.get(address);
+        InetSocketAddress clientAddress = this.clientAddresses.get(address);
+        return clientAddress != null ? clientAddress : address;
     }
 
     public void setClientAddress(InetSocketAddress address, InetSocketAddress clientAddress) {

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakServerChannel.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakServerChannel.java
@@ -45,6 +45,7 @@ import java.net.SocketAddress;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 public class RakServerChannel extends ProxyChannel<DatagramChannel> implements ServerChannel {
@@ -57,6 +58,7 @@ public class RakServerChannel extends ProxyChannel<DatagramChannel> implements S
     private final ExpiringMap<InetSocketAddress, InetSocketAddress> clientAddresses = ExpiringMap.builder()
             .expiration(RakConstants.SESSION_TIMEOUT_MS, TimeUnit.MILLISECONDS)
             .expirationPolicy(ExpirationPolicy.ACCESSED).build();
+    private final Map<InetAddress, AtomicInteger> connectionsPerIp = new ConcurrentHashMap<>();
 
     public RakServerChannel(DatagramChannel channel) {
         this(channel, null);
@@ -109,6 +111,15 @@ public class RakServerChannel extends ProxyChannel<DatagramChannel> implements S
         }
 
         InetSocketAddress clientAddress = this.getClientAddress(address);
+        int maxConnectionsPerIp = this.config().getMaxConnectionsPerIp();
+        if (maxConnectionsPerIp > 0) {
+            AtomicInteger connectionsPerIp = this.connectionsPerIp.computeIfAbsent(clientAddress.getAddress(), ignored -> new AtomicInteger());
+            if (connectionsPerIp.incrementAndGet() > maxConnectionsPerIp) {
+                connectionsPerIp.decrementAndGet();
+                return null;
+            }
+        }
+
         RakChildChannel channel = new RakChildChannel(address, localAddress, clientAddress, this, clientGuid, mtu, childConsumer);
         channel.closeFuture().addListener((GenericFutureListener<ChannelFuture>) this::onChildClosed);
         // Set before fireChannelRead because initChannel runs async on the child worker thread.
@@ -144,6 +155,11 @@ public class RakServerChannel extends ProxyChannel<DatagramChannel> implements S
         // DefaultChannelPipeline.destroy() is only called when channel.isOpen() is false,
         // but the method is called on parent channel, and there is no other way to destroy pipeline.
         RakUtils.destroyChannelPipeline(channel.rakPipeline());
+
+        AtomicInteger connectionsPerIp = this.connectionsPerIp.get(channel.remoteAddress().getAddress());
+        if (connectionsPerIp != null && connectionsPerIp.decrementAndGet() <= 0) {
+            this.connectionsPerIp.remove(channel.remoteAddress().getAddress());
+        }
     }
 
     @Override
@@ -159,7 +175,7 @@ public class RakServerChannel extends ProxyChannel<DatagramChannel> implements S
         combiner.finish(combinedPromise);
     }
 
-    public boolean tryBlockAddress(InetAddress address, long time, TimeUnit unit) {
+    public boolean tryBlockAddress(InetSocketAddress address, long time, TimeUnit unit) {
         RakServerRateLimiter rateLimiter = this.pipeline().get(RakServerRateLimiter.class);
         if (rateLimiter != null) {
             return rateLimiter.blockAddress(address, time, unit);

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/DefaultRakServerConfig.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/DefaultRakServerConfig.java
@@ -55,7 +55,7 @@ public class DefaultRakServerConfig extends DefaultChannelConfig implements RakS
     private volatile RakServerCookieMode cookieMode = RakServerCookieMode.ACTIVE;
     private volatile byte[] cookieSecret = new byte[32];
     private volatile SipHash sipHash;
-    private volatile boolean proxyProtocol = true;
+    private volatile boolean proxyProtocol;
 
     public DefaultRakServerConfig(RakServerChannel channel) {
         super(channel);
@@ -128,6 +128,9 @@ public class DefaultRakServerConfig extends DefaultChannelConfig implements RakS
         if (option == RakChannelOption.RAK_SERVER_COOKIE_SECRET) {
             return (T) this.getCookieSecret();
         }
+        if (option == RakChannelOption.PROXY_PROTOCOL) {
+            return (T) Boolean.valueOf(this.getProxyProtocol());
+        }
         return this.channel.parent().config().getOption(option);
     }
 
@@ -166,6 +169,8 @@ public class DefaultRakServerConfig extends DefaultChannelConfig implements RakS
             this.setCookieMode((RakServerCookieMode) value);
         } else if (option == RakChannelOption.RAK_SERVER_COOKIE_SECRET) {
             this.setCookieSecret((byte[]) value);
+        } else if (option == RakChannelOption.PROXY_PROTOCOL) {
+            this.setProxyProtocol((Boolean) value);
         } else {
             return this.channel.parent().config().setOption(option, value);
         }

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/DefaultRakServerConfig.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/DefaultRakServerConfig.java
@@ -43,6 +43,7 @@ public class DefaultRakServerConfig extends DefaultChannelConfig implements RakS
     private volatile long guid = ThreadLocalRandom.current().nextLong();
     private volatile int[] supportedProtocols;
     private volatile int maxConnections;
+    private volatile int maxConnectionsPerIp;
     private volatile ByteBuf unconnectedMagic = Unpooled.wrappedBuffer(DEFAULT_UNCONNECTED_MAGIC);
     private volatile ByteBuf advertisement;
     private volatile boolean handlePing;
@@ -77,7 +78,7 @@ public class DefaultRakServerConfig extends DefaultChannelConfig implements RakS
                 super.getOptions(),
                 RakChannelOption.RAK_GUID, RakChannelOption.RAK_MAX_CHANNELS, RakChannelOption.RAK_MAX_CONNECTIONS, RakChannelOption.RAK_SUPPORTED_PROTOCOLS, RakChannelOption.RAK_UNCONNECTED_MAGIC,
                 RakChannelOption.RAK_ADVERTISEMENT, RakChannelOption.RAK_HANDLE_PING, RakChannelOption.RAK_PACKET_LIMIT, RakChannelOption.RAK_GLOBAL_PACKET_LIMIT, RakChannelOption.RAK_SERVER_METRICS, 
-                RakChannelOption.RAK_IP_DONT_FRAGMENT, RakChannelOption.RAK_SERVER_COOKIE_MODE, RakChannelOption.RAK_SERVER_COOKIE_SECRET);
+                RakChannelOption.RAK_IP_DONT_FRAGMENT, RakChannelOption.RAK_SERVER_COOKIE_MODE, RakChannelOption.RAK_SERVER_COOKIE_SECRET, RakChannelOption.PROXY_PROTOCOL, RakChannelOption.RAK_MAX_CONNECTIONS_PER_IP);
     }
 
     @SuppressWarnings("unchecked")
@@ -97,6 +98,9 @@ public class DefaultRakServerConfig extends DefaultChannelConfig implements RakS
         }
         if (option == RakChannelOption.RAK_MAX_CONNECTIONS) {
             return (T) Integer.valueOf(this.getMaxConnections());
+        }
+        if (option == RakChannelOption.RAK_MAX_CONNECTIONS_PER_IP) {
+            return (T) Integer.valueOf(this.getMaxConnectionsPerIp());
         }
         if (option == RakChannelOption.RAK_SUPPORTED_PROTOCOLS) {
             return (T) this.getSupportedProtocols();
@@ -144,6 +148,8 @@ public class DefaultRakServerConfig extends DefaultChannelConfig implements RakS
             this.setMaxChannels((Integer) value);
         } else if (option == RakChannelOption.RAK_MAX_CONNECTIONS) {
             this.setMaxConnections((Integer) value);
+        } else if (option == RakChannelOption.RAK_MAX_CONNECTIONS_PER_IP) {
+            this.setMaxConnectionsPerIp((Integer) value);
         } else if (option == RakChannelOption.RAK_SUPPORTED_PROTOCOLS) {
             this.setSupportedProtocols((int[]) value);
         } else if (option == RakChannelOption.RAK_UNCONNECTED_MAGIC) {
@@ -226,6 +232,17 @@ public class DefaultRakServerConfig extends DefaultChannelConfig implements RakS
     @Override
     public RakServerChannelConfig setMaxConnections(int maxConnections) {
         this.maxConnections = maxConnections;
+        return this;
+    }
+
+    @Override
+    public int getMaxConnectionsPerIp() {
+        return this.maxConnectionsPerIp;
+    }
+
+    @Override
+    public RakServerChannelConfig setMaxConnectionsPerIp(int maxConnectionsPerIp) {
+        this.maxConnectionsPerIp = maxConnectionsPerIp;
         return this;
     }
 
@@ -361,7 +378,8 @@ public class DefaultRakServerConfig extends DefaultChannelConfig implements RakS
     }
 
     @Override
-    public void setProxyProtocol(boolean proxyProtocol) {
+    public RakServerChannelConfig setProxyProtocol(boolean proxyProtocol) {
         this.proxyProtocol = proxyProtocol;
+        return this;
     }
 }

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/DefaultRakServerConfig.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/DefaultRakServerConfig.java
@@ -55,6 +55,7 @@ public class DefaultRakServerConfig extends DefaultChannelConfig implements RakS
     private volatile RakServerCookieMode cookieMode = RakServerCookieMode.ACTIVE;
     private volatile byte[] cookieSecret = new byte[32];
     private volatile SipHash sipHash;
+    private volatile boolean proxyProtocol = true;
 
     public DefaultRakServerConfig(RakServerChannel channel) {
         super(channel);
@@ -347,5 +348,15 @@ public class DefaultRakServerConfig extends DefaultChannelConfig implements RakS
     @Override
     public SipHash getSipHash() {
         return this.sipHash;
+    }
+
+    @Override
+    public boolean getProxyProtocol() {
+        return this.proxyProtocol;
+    }
+
+    @Override
+    public void setProxyProtocol(boolean proxyProtocol) {
+        this.proxyProtocol = proxyProtocol;
     }
 }

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/DefaultRakServerConfig.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/DefaultRakServerConfig.java
@@ -57,6 +57,8 @@ public class DefaultRakServerConfig extends DefaultChannelConfig implements RakS
     private volatile byte[] cookieSecret = new byte[32];
     private volatile SipHash sipHash;
     private volatile boolean proxyProtocol;
+    private volatile long connectionThrottlePeriod = 4_000;
+    private volatile int connectionThrottleLimit = 3;
 
     public DefaultRakServerConfig(RakServerChannel channel) {
         super(channel);
@@ -78,7 +80,8 @@ public class DefaultRakServerConfig extends DefaultChannelConfig implements RakS
                 super.getOptions(),
                 RakChannelOption.RAK_GUID, RakChannelOption.RAK_MAX_CHANNELS, RakChannelOption.RAK_MAX_CONNECTIONS, RakChannelOption.RAK_SUPPORTED_PROTOCOLS, RakChannelOption.RAK_UNCONNECTED_MAGIC,
                 RakChannelOption.RAK_ADVERTISEMENT, RakChannelOption.RAK_HANDLE_PING, RakChannelOption.RAK_PACKET_LIMIT, RakChannelOption.RAK_GLOBAL_PACKET_LIMIT, RakChannelOption.RAK_SERVER_METRICS, 
-                RakChannelOption.RAK_IP_DONT_FRAGMENT, RakChannelOption.RAK_SERVER_COOKIE_MODE, RakChannelOption.RAK_SERVER_COOKIE_SECRET, RakChannelOption.PROXY_PROTOCOL, RakChannelOption.RAK_MAX_CONNECTIONS_PER_IP);
+                RakChannelOption.RAK_IP_DONT_FRAGMENT, RakChannelOption.RAK_SERVER_COOKIE_MODE, RakChannelOption.RAK_SERVER_COOKIE_SECRET, RakChannelOption.RAK_PROXY_PROTOCOL,
+                RakChannelOption.RAK_MAX_CONNECTIONS_PER_IP, RakChannelOption.RAK_CONNECTION_THROTTLE_PERIOD, RakChannelOption.RAK_CONNECTION_THROTTLE_LIMIT);
     }
 
     @SuppressWarnings("unchecked")
@@ -132,8 +135,14 @@ public class DefaultRakServerConfig extends DefaultChannelConfig implements RakS
         if (option == RakChannelOption.RAK_SERVER_COOKIE_SECRET) {
             return (T) this.getCookieSecret();
         }
-        if (option == RakChannelOption.PROXY_PROTOCOL) {
+        if (option == RakChannelOption.RAK_PROXY_PROTOCOL) {
             return (T) Boolean.valueOf(this.getProxyProtocol());
+        }
+        if (option == RakChannelOption.RAK_CONNECTION_THROTTLE_PERIOD) {
+            return (T) Long.valueOf(this.getConnectionThrottlePeriod());
+        }
+        if (option == RakChannelOption.RAK_CONNECTION_THROTTLE_LIMIT) {
+            return (T) Integer.valueOf(this.getConnectionThrottleLimit());
         }
         return this.channel.parent().config().getOption(option);
     }
@@ -175,8 +184,12 @@ public class DefaultRakServerConfig extends DefaultChannelConfig implements RakS
             this.setCookieMode((RakServerCookieMode) value);
         } else if (option == RakChannelOption.RAK_SERVER_COOKIE_SECRET) {
             this.setCookieSecret((byte[]) value);
-        } else if (option == RakChannelOption.PROXY_PROTOCOL) {
+        } else if (option == RakChannelOption.RAK_PROXY_PROTOCOL) {
             this.setProxyProtocol((Boolean) value);
+        } else if (option == RakChannelOption.RAK_CONNECTION_THROTTLE_PERIOD) {
+            this.setConnectionThrottlePeriod((Long) value);
+        } else if (option == RakChannelOption.RAK_CONNECTION_THROTTLE_LIMIT) {
+            this.setConnectionThrottleLimit((Integer) value);
         } else {
             return this.channel.parent().config().setOption(option, value);
         }
@@ -380,6 +393,28 @@ public class DefaultRakServerConfig extends DefaultChannelConfig implements RakS
     @Override
     public RakServerChannelConfig setProxyProtocol(boolean proxyProtocol) {
         this.proxyProtocol = proxyProtocol;
+        return this;
+    }
+
+    @Override
+    public long getConnectionThrottlePeriod() {
+        return this.connectionThrottlePeriod;
+    }
+
+    @Override
+    public RakServerChannelConfig setConnectionThrottlePeriod(long connectionThrottlePeriod) {
+        this.connectionThrottlePeriod = connectionThrottlePeriod;
+        return this;
+    }
+
+    @Override
+    public int getConnectionThrottleLimit() {
+        return this.connectionThrottleLimit;
+    }
+
+    @Override
+    public RakServerChannelConfig setConnectionThrottleLimit(int throttleWindowConnections) {
+        this.connectionThrottleLimit = throttleWindowConnections;
         return this;
     }
 }

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/DefaultRakServerConfig.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/DefaultRakServerConfig.java
@@ -43,7 +43,6 @@ public class DefaultRakServerConfig extends DefaultChannelConfig implements RakS
     private volatile long guid = ThreadLocalRandom.current().nextLong();
     private volatile int[] supportedProtocols;
     private volatile int maxConnections;
-    private volatile int maxConnectionsPerIp = 10;
     private volatile ByteBuf unconnectedMagic = Unpooled.wrappedBuffer(DEFAULT_UNCONNECTED_MAGIC);
     private volatile ByteBuf advertisement;
     private volatile boolean handlePing;
@@ -57,8 +56,7 @@ public class DefaultRakServerConfig extends DefaultChannelConfig implements RakS
     private volatile byte[] cookieSecret = new byte[32];
     private volatile SipHash sipHash;
     private volatile boolean proxyProtocol;
-    private volatile long connectionThrottlePeriod = 4_000;
-    private volatile int connectionThrottleLimit = 3;
+    private volatile RakServerThrottle throttle;
 
     public DefaultRakServerConfig(RakServerChannel channel) {
         super(channel);
@@ -80,8 +78,7 @@ public class DefaultRakServerConfig extends DefaultChannelConfig implements RakS
                 super.getOptions(),
                 RakChannelOption.RAK_GUID, RakChannelOption.RAK_MAX_CHANNELS, RakChannelOption.RAK_MAX_CONNECTIONS, RakChannelOption.RAK_SUPPORTED_PROTOCOLS, RakChannelOption.RAK_UNCONNECTED_MAGIC,
                 RakChannelOption.RAK_ADVERTISEMENT, RakChannelOption.RAK_HANDLE_PING, RakChannelOption.RAK_PACKET_LIMIT, RakChannelOption.RAK_GLOBAL_PACKET_LIMIT, RakChannelOption.RAK_SERVER_METRICS, 
-                RakChannelOption.RAK_IP_DONT_FRAGMENT, RakChannelOption.RAK_SERVER_COOKIE_MODE, RakChannelOption.RAK_SERVER_COOKIE_SECRET, RakChannelOption.RAK_PROXY_PROTOCOL,
-                RakChannelOption.RAK_MAX_CONNECTIONS_PER_IP, RakChannelOption.RAK_CONNECTION_THROTTLE_PERIOD, RakChannelOption.RAK_CONNECTION_THROTTLE_LIMIT);
+                RakChannelOption.RAK_IP_DONT_FRAGMENT, RakChannelOption.RAK_SERVER_COOKIE_MODE, RakChannelOption.RAK_SERVER_COOKIE_SECRET, RakChannelOption.RAK_PROXY_PROTOCOL, RakChannelOption.RAK_THROTTLE);
     }
 
     @SuppressWarnings("unchecked")
@@ -101,9 +98,6 @@ public class DefaultRakServerConfig extends DefaultChannelConfig implements RakS
         }
         if (option == RakChannelOption.RAK_MAX_CONNECTIONS) {
             return (T) Integer.valueOf(this.getMaxConnections());
-        }
-        if (option == RakChannelOption.RAK_MAX_CONNECTIONS_PER_IP) {
-            return (T) Integer.valueOf(this.getMaxConnectionsPerIp());
         }
         if (option == RakChannelOption.RAK_SUPPORTED_PROTOCOLS) {
             return (T) this.getSupportedProtocols();
@@ -138,11 +132,8 @@ public class DefaultRakServerConfig extends DefaultChannelConfig implements RakS
         if (option == RakChannelOption.RAK_PROXY_PROTOCOL) {
             return (T) Boolean.valueOf(this.getProxyProtocol());
         }
-        if (option == RakChannelOption.RAK_CONNECTION_THROTTLE_PERIOD) {
-            return (T) Long.valueOf(this.getConnectionThrottlePeriod());
-        }
-        if (option == RakChannelOption.RAK_CONNECTION_THROTTLE_LIMIT) {
-            return (T) Integer.valueOf(this.getConnectionThrottleLimit());
+        if (option == RakChannelOption.RAK_THROTTLE) {
+            return (T) this.getThrottle();
         }
         return this.channel.parent().config().getOption(option);
     }
@@ -157,8 +148,6 @@ public class DefaultRakServerConfig extends DefaultChannelConfig implements RakS
             this.setMaxChannels((Integer) value);
         } else if (option == RakChannelOption.RAK_MAX_CONNECTIONS) {
             this.setMaxConnections((Integer) value);
-        } else if (option == RakChannelOption.RAK_MAX_CONNECTIONS_PER_IP) {
-            this.setMaxConnectionsPerIp((Integer) value);
         } else if (option == RakChannelOption.RAK_SUPPORTED_PROTOCOLS) {
             this.setSupportedProtocols((int[]) value);
         } else if (option == RakChannelOption.RAK_UNCONNECTED_MAGIC) {
@@ -186,10 +175,8 @@ public class DefaultRakServerConfig extends DefaultChannelConfig implements RakS
             this.setCookieSecret((byte[]) value);
         } else if (option == RakChannelOption.RAK_PROXY_PROTOCOL) {
             this.setProxyProtocol((Boolean) value);
-        } else if (option == RakChannelOption.RAK_CONNECTION_THROTTLE_PERIOD) {
-            this.setConnectionThrottlePeriod((Long) value);
-        } else if (option == RakChannelOption.RAK_CONNECTION_THROTTLE_LIMIT) {
-            this.setConnectionThrottleLimit((Integer) value);
+        } else if (option == RakChannelOption.RAK_THROTTLE) {
+            this.setThrottle((RakServerThrottle) value);
         } else {
             return this.channel.parent().config().setOption(option, value);
         }
@@ -245,17 +232,6 @@ public class DefaultRakServerConfig extends DefaultChannelConfig implements RakS
     @Override
     public RakServerChannelConfig setMaxConnections(int maxConnections) {
         this.maxConnections = maxConnections;
-        return this;
-    }
-
-    @Override
-    public int getMaxConnectionsPerIp() {
-        return this.maxConnectionsPerIp;
-    }
-
-    @Override
-    public RakServerChannelConfig setMaxConnectionsPerIp(int maxConnectionsPerIp) {
-        this.maxConnectionsPerIp = maxConnectionsPerIp;
         return this;
     }
 
@@ -397,24 +373,13 @@ public class DefaultRakServerConfig extends DefaultChannelConfig implements RakS
     }
 
     @Override
-    public long getConnectionThrottlePeriod() {
-        return this.connectionThrottlePeriod;
+    public RakServerThrottle getThrottle() {
+        return this.throttle;
     }
 
     @Override
-    public RakServerChannelConfig setConnectionThrottlePeriod(long connectionThrottlePeriod) {
-        this.connectionThrottlePeriod = connectionThrottlePeriod;
-        return this;
-    }
-
-    @Override
-    public int getConnectionThrottleLimit() {
-        return this.connectionThrottleLimit;
-    }
-
-    @Override
-    public RakServerChannelConfig setConnectionThrottleLimit(int throttleWindowConnections) {
-        this.connectionThrottleLimit = throttleWindowConnections;
+    public RakServerChannelConfig setThrottle(RakServerThrottle throttle) {
+        this.throttle = throttle;
         return this;
     }
 }

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/DefaultRakServerConfig.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/DefaultRakServerConfig.java
@@ -43,7 +43,7 @@ public class DefaultRakServerConfig extends DefaultChannelConfig implements RakS
     private volatile long guid = ThreadLocalRandom.current().nextLong();
     private volatile int[] supportedProtocols;
     private volatile int maxConnections;
-    private volatile int maxConnectionsPerIp;
+    private volatile int maxConnectionsPerIp = 10;
     private volatile ByteBuf unconnectedMagic = Unpooled.wrappedBuffer(DEFAULT_UNCONNECTED_MAGIC);
     private volatile ByteBuf advertisement;
     private volatile boolean handlePing;

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/DefaultRakServerThrottle.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/DefaultRakServerThrottle.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 CloudburstMC
+ *
+ * CloudburstMC licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.cloudburstmc.netty.channel.raknet.config;
+
+import net.jodah.expiringmap.ExpirationPolicy;
+import net.jodah.expiringmap.ExpiringMap;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class DefaultRakServerThrottle implements RakServerThrottle {
+    private final Map<InetAddress, AtomicInteger> connectionsPerIp;
+    private final int connectionsPerIpMax;
+
+    private final ExpiringMap<InetAddress, AtomicInteger> connects;
+    private final int connectsMax;
+
+    public DefaultRakServerThrottle() {
+        this(10, 4_000, 3);
+    }
+
+    public DefaultRakServerThrottle(int connectionsPerIpMax, long connectWindowInMs, int connectsMax) {
+        this.connectionsPerIp = new ConcurrentHashMap<>();
+        this.connectionsPerIpMax = connectionsPerIpMax;
+
+        this.connects = ExpiringMap.builder()
+                .expiration(connectWindowInMs, TimeUnit.MILLISECONDS)
+                .expirationPolicy(ExpirationPolicy.CREATED)
+                .build();
+        this.connectsMax = connectsMax;
+    }
+
+    @Override
+    public boolean accept(InetSocketAddress address) {
+        AtomicInteger connectionsPerIp = this.connectionsPerIp.computeIfAbsent(address.getAddress(), ignored -> new AtomicInteger());
+        if (connectionsPerIp.get() >= connectionsPerIpMax) {
+            return false;
+        }
+        connectionsPerIp.incrementAndGet();
+
+        AtomicInteger attempts = this.connects.computeIfAbsent(address.getAddress(), ignored -> new AtomicInteger());
+        if (attempts.get() > connectsMax) {
+            return false;
+        }
+        attempts.incrementAndGet();
+
+        return true;
+    }
+
+    @Override
+    public void closed(InetSocketAddress address) {
+        AtomicInteger connectionsPerIp = this.connectionsPerIp.get(address.getAddress());
+        if (connectionsPerIp != null && connectionsPerIp.decrementAndGet() <= 0) {
+            this.connectionsPerIp.remove(address.getAddress());
+        }
+    }
+}

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/DefaultRakServerThrottle.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/DefaultRakServerThrottle.java
@@ -27,8 +27,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class DefaultRakServerThrottle implements RakServerThrottle {
-    private final Map<InetAddress, AtomicInteger> connectionsPerIp;
-    private final int connectionsPerIpMax;
+    private final Map<InetAddress, AtomicInteger> connections;
+    private final int connectionsMax;
 
     private final ExpiringMap<InetAddress, AtomicInteger> connects;
     private final int connectsMax;
@@ -37,9 +37,9 @@ public class DefaultRakServerThrottle implements RakServerThrottle {
         this(10, 4_000, 3);
     }
 
-    public DefaultRakServerThrottle(int connectionsPerIpMax, long connectWindowInMs, int connectsMax) {
-        this.connectionsPerIp = new ConcurrentHashMap<>();
-        this.connectionsPerIpMax = connectionsPerIpMax;
+    public DefaultRakServerThrottle(int connectionsMax, long connectWindowInMs, int connectsMax) {
+        this.connections = new ConcurrentHashMap<>();
+        this.connectionsMax = connectionsMax;
 
         this.connects = ExpiringMap.builder()
                 .expiration(connectWindowInMs, TimeUnit.MILLISECONDS)
@@ -50,11 +50,11 @@ public class DefaultRakServerThrottle implements RakServerThrottle {
 
     @Override
     public boolean accept(InetSocketAddress address) {
-        AtomicInteger connectionsPerIp = this.connectionsPerIp.computeIfAbsent(address.getAddress(), ignored -> new AtomicInteger());
-        if (connectionsPerIp.get() >= connectionsPerIpMax) {
+        AtomicInteger connections = this.connections.computeIfAbsent(address.getAddress(), ignored -> new AtomicInteger());
+        if (connections.get() >= connectionsMax) {
             return false;
         }
-        connectionsPerIp.incrementAndGet();
+        connections.incrementAndGet();
 
         AtomicInteger attempts = this.connects.computeIfAbsent(address.getAddress(), ignored -> new AtomicInteger());
         if (attempts.get() > connectsMax) {
@@ -67,9 +67,9 @@ public class DefaultRakServerThrottle implements RakServerThrottle {
 
     @Override
     public void closed(InetSocketAddress address) {
-        AtomicInteger connectionsPerIp = this.connectionsPerIp.get(address.getAddress());
+        AtomicInteger connectionsPerIp = this.connections.get(address.getAddress());
         if (connectionsPerIp != null && connectionsPerIp.decrementAndGet() <= 0) {
-            this.connectionsPerIp.remove(address.getAddress());
+            this.connections.remove(address.getAddress());
         }
     }
 }

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/DefaultRakServerThrottle.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/DefaultRakServerThrottle.java
@@ -54,13 +54,14 @@ public class DefaultRakServerThrottle implements RakServerThrottle {
         if (connections.get() >= connectionsMax) {
             return false;
         }
-        connections.incrementAndGet();
 
-        AtomicInteger attempts = this.connects.computeIfAbsent(address.getAddress(), ignored -> new AtomicInteger());
-        if (attempts.get() > connectsMax) {
+        AtomicInteger connects = this.connects.computeIfAbsent(address.getAddress(), ignored -> new AtomicInteger());
+        if (connects.get() >= connectsMax) {
             return false;
         }
-        attempts.incrementAndGet();
+        connects.incrementAndGet();
+
+        connections.incrementAndGet();
 
         return true;
     }

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/RakChannelOption.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/RakChannelOption.java
@@ -70,6 +70,12 @@ public class RakChannelOption<T> extends ChannelOption<T> {
             valueOf(RakChannelOption.class, "RAK_MAX_CONNECTIONS");
 
     /**
+     * Maximum allowed connections per ip to the RakNet server. Subsequent connections will be denied.
+     */
+    public static final ChannelOption<Integer> RAK_MAX_CONNECTIONS_PER_IP =
+            valueOf(RakChannelOption.class, "MAX_CONNECTIONS_PER_IP");
+
+    /**
      * RakNet protocol version to send to remote peer.
      */
     public static final ChannelOption<Integer> RAK_PROTOCOL_VERSION =
@@ -202,7 +208,7 @@ public class RakChannelOption<T> extends ChannelOption<T> {
             valueOf(RakChannelOption.class, "RAK_SERVER_COOKIE_SECRET");
 
     /**
-     * Use proxy protocol to determine the client's ip
+     * Use proxy protocol to determine the client's ip.
      */
     public static final ChannelOption<byte[]> PROXY_PROTOCOL =
             valueOf(RakChannelOption.class, "PROXY_PROTOCOL");

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/RakChannelOption.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/RakChannelOption.java
@@ -70,12 +70,6 @@ public class RakChannelOption<T> extends ChannelOption<T> {
             valueOf(RakChannelOption.class, "RAK_MAX_CONNECTIONS");
 
     /**
-     * Maximum allowed connections per ip to the RakNet server. Subsequent connections will be denied.
-     */
-    public static final ChannelOption<Integer> RAK_MAX_CONNECTIONS_PER_IP =
-            valueOf(RakChannelOption.class, "MAX_CONNECTIONS_PER_IP");
-
-    /**
      * RakNet protocol version to send to remote peer.
      */
     public static final ChannelOption<Integer> RAK_PROTOCOL_VERSION =
@@ -212,18 +206,12 @@ public class RakChannelOption<T> extends ChannelOption<T> {
      */
     public static final ChannelOption<Boolean> RAK_PROXY_PROTOCOL =
             valueOf(RakChannelOption.class, "RAK_PROXY_PROTOCOL");
-    /**
-     * The duration new connection attempts should be grouped together.
-     */
-    public static final ChannelOption<Long> RAK_CONNECTION_THROTTLE_PERIOD =
-            valueOf(RakChannelOption.class, "RAK_CONNECTION_THROTTLE_PERIOD");
 
     /**
-     * How many new connections can occur within the duration.
+     * Called to determine if a connection should be accepted.
      */
-    public static final ChannelOption<Integer> RAK_CONNECTION_THROTTLE_LIMIT =
-            valueOf(RakChannelOption.class, "RAK_CONNECTION_THROTTLE_LIMIT");
-
+    public static final ChannelOption<RakServerThrottle> RAK_THROTTLE =
+            valueOf(RakChannelOption.class, "RAK_THROTTLE");
 
     @SuppressWarnings("deprecation")
     protected RakChannelOption() {

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/RakChannelOption.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/RakChannelOption.java
@@ -210,7 +210,7 @@ public class RakChannelOption<T> extends ChannelOption<T> {
     /**
      * Use proxy protocol to determine the client's ip.
      */
-    public static final ChannelOption<byte[]> PROXY_PROTOCOL =
+    public static final ChannelOption<Boolean> PROXY_PROTOCOL =
             valueOf(RakChannelOption.class, "PROXY_PROTOCOL");
 
     @SuppressWarnings("deprecation")

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/RakChannelOption.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/RakChannelOption.java
@@ -210,8 +210,20 @@ public class RakChannelOption<T> extends ChannelOption<T> {
     /**
      * Use proxy protocol to determine the client's ip.
      */
-    public static final ChannelOption<Boolean> PROXY_PROTOCOL =
-            valueOf(RakChannelOption.class, "PROXY_PROTOCOL");
+    public static final ChannelOption<Boolean> RAK_PROXY_PROTOCOL =
+            valueOf(RakChannelOption.class, "RAK_PROXY_PROTOCOL");
+    /**
+     * The duration new connection attempts should be grouped together.
+     */
+    public static final ChannelOption<Long> RAK_CONNECTION_THROTTLE_PERIOD =
+            valueOf(RakChannelOption.class, "RAK_CONNECTION_THROTTLE_PERIOD");
+
+    /**
+     * How many new connections can occur within the duration.
+     */
+    public static final ChannelOption<Integer> RAK_CONNECTION_THROTTLE_LIMIT =
+            valueOf(RakChannelOption.class, "RAK_CONNECTION_THROTTLE_LIMIT");
+
 
     @SuppressWarnings("deprecation")
     protected RakChannelOption() {

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/RakChannelOption.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/RakChannelOption.java
@@ -195,11 +195,17 @@ public class RakChannelOption<T> extends ChannelOption<T> {
     public static final ChannelOption<RakServerCookieMode> RAK_SERVER_COOKIE_MODE =
             valueOf(RakChannelOption.class, "RAK_SERVER_COOKIE_MODE");
 
-    /*
+    /**
      * The secret key used for generating stateless cookies. Must be exactly 16 bytes. One will be generated if not set.
      */
     public static final ChannelOption<byte[]> RAK_SERVER_COOKIE_SECRET =
             valueOf(RakChannelOption.class, "RAK_SERVER_COOKIE_SECRET");
+
+    /**
+     * Use proxy protocol to determine the client's ip
+     */
+    public static final ChannelOption<byte[]> PROXY_PROTOCOL =
+            valueOf(RakChannelOption.class, "PROXY_PROTOCOL");
 
     @SuppressWarnings("deprecation")
     protected RakChannelOption() {

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/RakServerChannelConfig.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/RakServerChannelConfig.java
@@ -38,6 +38,10 @@ public interface RakServerChannelConfig extends ChannelConfig {
 
     RakServerChannelConfig setMaxConnections(int maxConnections);
 
+    int getMaxConnectionsPerIp();
+
+    RakServerChannelConfig setMaxConnectionsPerIp(int maxConnectionsPerIp);
+
     ByteBuf getUnconnectedMagic();
 
     RakServerChannelConfig setUnconnectedMagic(ByteBuf unconnectedMagic);
@@ -84,5 +88,5 @@ public interface RakServerChannelConfig extends ChannelConfig {
 
     boolean getProxyProtocol();
 
-    void setProxyProtocol(boolean proxyProtocol);
+    RakServerChannelConfig setProxyProtocol(boolean proxyProtocol);
 }

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/RakServerChannelConfig.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/RakServerChannelConfig.java
@@ -89,4 +89,12 @@ public interface RakServerChannelConfig extends ChannelConfig {
     boolean getProxyProtocol();
 
     RakServerChannelConfig setProxyProtocol(boolean proxyProtocol);
+
+    long getConnectionThrottlePeriod();
+
+    RakServerChannelConfig setConnectionThrottlePeriod(long connectionThrottlePeriod);
+
+    int getConnectionThrottleLimit();
+
+    RakServerChannelConfig setConnectionThrottleLimit(int connectionThrottleLimit);
 }

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/RakServerChannelConfig.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/RakServerChannelConfig.java
@@ -38,10 +38,6 @@ public interface RakServerChannelConfig extends ChannelConfig {
 
     RakServerChannelConfig setMaxConnections(int maxConnections);
 
-    int getMaxConnectionsPerIp();
-
-    RakServerChannelConfig setMaxConnectionsPerIp(int maxConnectionsPerIp);
-
     ByteBuf getUnconnectedMagic();
 
     RakServerChannelConfig setUnconnectedMagic(ByteBuf unconnectedMagic);
@@ -90,11 +86,7 @@ public interface RakServerChannelConfig extends ChannelConfig {
 
     RakServerChannelConfig setProxyProtocol(boolean proxyProtocol);
 
-    long getConnectionThrottlePeriod();
+    RakServerThrottle getThrottle();
 
-    RakServerChannelConfig setConnectionThrottlePeriod(long connectionThrottlePeriod);
-
-    int getConnectionThrottleLimit();
-
-    RakServerChannelConfig setConnectionThrottleLimit(int connectionThrottleLimit);
+    RakServerChannelConfig setThrottle(RakServerThrottle throttle);
 }

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/RakServerChannelConfig.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/RakServerChannelConfig.java
@@ -81,4 +81,8 @@ public interface RakServerChannelConfig extends ChannelConfig {
     RakServerChannelConfig setCookieSecret(byte[] secret);
 
     SipHash getSipHash();
+
+    boolean getProxyProtocol();
+
+    void setProxyProtocol(boolean proxyProtocol);
 }

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/RakServerMetrics.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/RakServerMetrics.java
@@ -36,10 +36,10 @@ public interface RakServerMetrics {
     default void connectionInitPacket(InetSocketAddress address, int packetId) {
     }
 
-    default void addressBlocked(InetAddress address) {
+    default void addressBlocked(InetSocketAddress address) {
     }
 
-    default void addressUnblocked(InetAddress address) {
+    default void addressUnblocked(InetSocketAddress address) {
     }
 
     default void invalidCookie(InetSocketAddress address) {

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/RakServerThrottle.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/config/RakServerThrottle.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 CloudburstMC
+ *
+ * CloudburstMC licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.cloudburstmc.netty.channel.raknet.config;
+
+import java.net.InetSocketAddress;
+
+public interface RakServerThrottle {
+    boolean accept(InetSocketAddress address);
+
+    void closed(InetSocketAddress address);
+}

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/server/RakChildDatagramHandler.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/server/RakChildDatagramHandler.java
@@ -45,7 +45,7 @@ public class RakChildDatagramHandler extends ChannelOutboundHandlerAdapter {
         this.canFlush = true;
         promise.trySuccess();
         DatagramPacket datagram = isDatagram ? (DatagramPacket) msg :
-                new DatagramPacket((ByteBuf) msg, this.channel.remoteAddress(), this.channel.localAddress());
+                new DatagramPacket((ByteBuf) msg, this.channel.remoteOrProxyAddress(), this.channel.localAddress());
 
         RakChannelMetrics metrics = this.channel.config().getMetrics();
         if (metrics != null) {

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/server/RakChildDatagramHandler.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/server/RakChildDatagramHandler.java
@@ -45,7 +45,7 @@ public class RakChildDatagramHandler extends ChannelOutboundHandlerAdapter {
         this.canFlush = true;
         promise.trySuccess();
         DatagramPacket datagram = isDatagram ? (DatagramPacket) msg :
-                new DatagramPacket((ByteBuf) msg, this.channel.remoteOrProxyAddress(), this.channel.localAddress());
+                new DatagramPacket((ByteBuf) msg, this.channel.remoteAddress(), this.channel.localAddress());
 
         RakChannelMetrics metrics = this.channel.config().getMetrics();
         if (metrics != null) {

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/server/RakProxyServerHandler.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/server/RakProxyServerHandler.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2019-2023 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.cloudburstmc.netty.handler.codec.raknet.server;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.handler.codec.haproxy.HAProxyMessage;
+import io.netty.handler.codec.haproxy.HAProxyProtocolException;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+import org.cloudburstmc.netty.channel.proxy.ProxyProtocolDecoder;
+import org.cloudburstmc.netty.channel.raknet.RakServerChannel;
+
+import java.net.InetSocketAddress;
+
+public class RakProxyServerHandler extends SimpleChannelInboundHandler<DatagramPacket> {
+    private static final InternalLogger log = InternalLoggerFactory.getInstance(RakProxyServerHandler.class);
+    public static final String NAME = "rak-proxy-server-handler";
+    private final RakServerChannel parent;
+
+    public RakProxyServerHandler(RakServerChannel parent) {
+        this.parent = parent;
+    }
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, DatagramPacket packet) {
+        ByteBuf content = packet.content();
+        int detectedVersion = ProxyProtocolDecoder.findVersion(content);
+        InetSocketAddress presentAddress = parent.getClientAddress(packet.sender());
+
+        if (presentAddress == null && detectedVersion == -1) {
+            // We haven't received a header from given address before and we couldn't detect a
+            // PROXY header, ignore.
+            return;
+        }
+
+        if (presentAddress == null) {
+            final HAProxyMessage decoded;
+            try {
+                if ((decoded = ProxyProtocolDecoder.decode(content, detectedVersion)) == null) {
+                    // PROXY header was not present in the packet, ignore.
+                    return;
+                }
+            } catch (HAProxyProtocolException e) {
+                log.debug("{} sent malformed PROXY header", packet.sender(), e);
+                return;
+            }
+
+            presentAddress = new InetSocketAddress(decoded.sourceAddress(), decoded.sourcePort());
+            log.debug("Got PROXY header: (from {}) {}", packet.sender(), presentAddress);
+            parent.setClientAddress(packet.sender(), presentAddress);
+        } else {
+            log.trace("Reusing PROXY header: (from {}) {}", packet.sender(), presentAddress);
+        }
+
+        ctx.fireChannelRead(packet.retain());
+    }
+}

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/server/RakProxyServerHandler.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/server/RakProxyServerHandler.java
@@ -33,8 +33,8 @@ import io.netty.handler.codec.haproxy.HAProxyMessage;
 import io.netty.handler.codec.haproxy.HAProxyProtocolException;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import org.cloudburstmc.netty.channel.proxy.ProxyProtocolDecoder;
 import org.cloudburstmc.netty.channel.raknet.RakServerChannel;
+import org.cloudburstmc.netty.util.ProxyProtocolDecoder;
 
 import java.net.InetSocketAddress;
 

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/server/RakServerRateLimiter.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/server/RakServerRateLimiter.java
@@ -26,6 +26,7 @@ import org.cloudburstmc.netty.channel.raknet.RakServerChannel;
 import org.cloudburstmc.netty.channel.raknet.config.RakServerMetrics;
 
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -143,7 +144,8 @@ public class RakServerRateLimiter extends SimpleChannelInboundHandler<DatagramPa
             return;
         }
 
-        InetAddress address = datagram.sender().getAddress();
+        InetSocketAddress clientAddress = channel.getClientAddress(datagram.sender());
+        InetAddress address = clientAddress != null ? clientAddress.getAddress() : datagram.sender().getAddress();
         if (this.blockedConnections.containsKey(address)) {
             return;
         }

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/server/RakServerRateLimiter.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/server/RakServerRateLimiter.java
@@ -144,8 +144,7 @@ public class RakServerRateLimiter extends SimpleChannelInboundHandler<DatagramPa
             return;
         }
 
-        InetSocketAddress clientAddress = channel.getClientAddress(datagram.sender());
-        InetAddress address = clientAddress != null ? clientAddress.getAddress() : datagram.sender().getAddress();
+        InetAddress address = channel.getClientAddress(datagram.sender()).getAddress();
         if (this.blockedConnections.containsKey(address)) {
             return;
         }

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/server/RakServerRateLimiter.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/server/RakServerRateLimiter.java
@@ -144,7 +144,7 @@ public class RakServerRateLimiter extends SimpleChannelInboundHandler<DatagramPa
             return;
         }
 
-        InetSocketAddress address = channel.getClientAddress(datagram.sender());
+        InetSocketAddress address = datagram.sender();
         if (this.blockedConnections.containsKey(address)) {
             return;
         }

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/server/RakServerRateLimiter.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/server/RakServerRateLimiter.java
@@ -39,10 +39,10 @@ public class RakServerRateLimiter extends SimpleChannelInboundHandler<DatagramPa
 
     private final RakServerChannel channel;
 
-    private final ConcurrentHashMap<InetAddress, AtomicInteger> rateLimitMap = new ConcurrentHashMap<>();
-    private final Map<InetAddress, Long> blockedConnections = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<InetSocketAddress, AtomicInteger> rateLimitMap = new ConcurrentHashMap<>();
+    private final Map<InetSocketAddress, Long> blockedConnections = new ConcurrentHashMap<>();
 
-    private final Collection<InetAddress> exceptions = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private final Collection<InetSocketAddress> exceptions = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     private final AtomicLong globalCounter = new AtomicLong(0);
 
@@ -76,9 +76,9 @@ public class RakServerRateLimiter extends SimpleChannelInboundHandler<DatagramPa
 
         RakServerMetrics metrics = this.channel.config().getMetrics();
 
-        Iterator<Map.Entry<InetAddress, Long>> iterator = this.blockedConnections.entrySet().iterator();
+        Iterator<Map.Entry<InetSocketAddress, Long>> iterator = this.blockedConnections.entrySet().iterator();
         while (iterator.hasNext()) {
-            Map.Entry<InetAddress, Long> entry = iterator.next();
+            Map.Entry<InetSocketAddress, Long> entry = iterator.next();
             if (entry.getValue() != 0 && currTime > entry.getValue()) {
                 iterator.remove();
                 log.info("Unblocked address {}", entry.getKey());
@@ -89,7 +89,7 @@ public class RakServerRateLimiter extends SimpleChannelInboundHandler<DatagramPa
         }
     }
 
-    public boolean blockAddress(InetAddress address, long time, TimeUnit unit) {
+    public boolean blockAddress(InetSocketAddress address, long time, TimeUnit unit) {
         if (this.exceptions.contains(address)) {
             return false;
         }
@@ -103,7 +103,7 @@ public class RakServerRateLimiter extends SimpleChannelInboundHandler<DatagramPa
         return true;
     }
 
-    public void unblockAddress(InetAddress address) {
+    public void unblockAddress(InetSocketAddress address) {
         if (this.blockedConnections.remove(address) == null) {
             return;
         }
@@ -115,23 +115,23 @@ public class RakServerRateLimiter extends SimpleChannelInboundHandler<DatagramPa
         }
     }
 
-    public boolean isAddressBlocked(InetAddress address) {
+    public boolean isAddressBlocked(InetSocketAddress address) {
         return this.blockedConnections.containsKey(address);
     }
 
-    public void addException(InetAddress address) {
+    public void addException(InetSocketAddress address) {
         this.exceptions.add(address);
     }
 
-    public void removeException(InetAddress address) {
+    public void removeException(InetSocketAddress address) {
         this.exceptions.remove(address);
     }
 
-    public Collection<InetAddress> getExceptions() {
+    public Collection<InetSocketAddress> getExceptions() {
         return Collections.unmodifiableCollection(this.exceptions);
     }
 
-    protected int getAddressMaxPacketCount(InetAddress address) {
+    protected int getAddressMaxPacketCount(InetSocketAddress address) {
         return this.channel.config().getPacketLimit();
     }
 
@@ -144,7 +144,7 @@ public class RakServerRateLimiter extends SimpleChannelInboundHandler<DatagramPa
             return;
         }
 
-        InetAddress address = channel.getClientAddress(datagram.sender()).getAddress();
+        InetSocketAddress address = channel.getClientAddress(datagram.sender());
         if (this.blockedConnections.containsKey(address)) {
             return;
         }

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/util/ProxyProtocolDecoder.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/util/ProxyProtocolDecoder.java
@@ -23,7 +23,7 @@
  * @link https://github.com/GeyserMC/Geyser
  */
 
-package org.cloudburstmc.netty.channel.proxy;
+package org.cloudburstmc.netty.util;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.ProtocolDetectionResult;

--- a/transport-raknet/src/test/java/org/cloudburstmc/netty/RakProxyTests.java
+++ b/transport-raknet/src/test/java/org/cloudburstmc/netty/RakProxyTests.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026 CloudburstMC
+ *
+ * CloudburstMC licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.cloudburstmc.netty;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.*;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+import io.netty.util.ReferenceCountUtil;
+import org.cloudburstmc.netty.channel.raknet.RakChannelFactory;
+import org.cloudburstmc.netty.channel.raknet.RakClientChannel;
+import org.cloudburstmc.netty.channel.raknet.config.RakChannelOption;
+import org.cloudburstmc.netty.handler.codec.raknet.client.RakClientProxyRouteHandler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+
+public class RakProxyTests {
+
+    private static final int PORT = 19134;
+    private static final int PROTOCOL_VERSION = 11;
+    private static final InetSocketAddress FAKE = new InetSocketAddress("8.8.8.8", 12345);
+
+    private EventLoopGroup group;
+    private Channel serverChannel;
+
+    @BeforeEach
+    public void setup() {
+        group = new NioEventLoopGroup();
+    }
+
+    @AfterEach
+    public void teardown() {
+        if (serverChannel != null) {
+            serverChannel.close().awaitUninterruptibly();
+        }
+        group.shutdownGracefully().awaitUninterruptibly();
+    }
+
+    private void setupServer() {
+        ServerBootstrap b = new ServerBootstrap()
+                .channelFactory(RakChannelFactory.server(NioDatagramChannel.class))
+                .group(group)
+                .option(RakChannelOption.RAK_PROXY_PROTOCOL, true)
+                .childHandler(new ChannelInitializer<Channel>() {
+                    @Override
+                    protected void initChannel(Channel ch) {
+                        if (!ch.remoteAddress().equals(FAKE)) {
+                            ch.close();
+                        }
+                    }
+                });
+
+        this.serverChannel = b.bind(new InetSocketAddress(PORT)).awaitUninterruptibly().channel();
+    }
+
+    private Bootstrap clientBootstrap() {
+        return new Bootstrap()
+                .channelFactory(RakChannelFactory.client(NioDatagramChannel.class))
+                .group(group)
+                .option(RakChannelOption.RAK_PROTOCOL_VERSION, PROTOCOL_VERSION)
+                .handler(new ChannelInitializer<RakClientChannel>() {
+                    @Override
+                    protected void initChannel(RakClientChannel ch) {
+                        ch.rakPipeline().addBefore(
+                                RakClientProxyRouteHandler.NAME,
+                                "proxy-protocol-header",
+                                new ProxyProtocolHeaderPrepender()
+                        );
+                    }
+                });
+    }
+
+    @Test
+    public void testProxyProtocol() {
+        setupServer();
+
+        Channel client = clientBootstrap()
+                .connect(new InetSocketAddress("127.0.0.1", PORT))
+                .awaitUninterruptibly()
+                .channel();
+
+        Assertions.assertTrue(client.isActive(), "Client should connect with fake IP");
+        client.close().awaitUninterruptibly();
+    }
+
+    private static class ProxyProtocolHeaderPrepender extends ChannelOutboundHandlerAdapter {
+
+        private static final byte[] PROXY_V2_SIGNATURE = new byte[]{
+                0x0D, 0x0A, 0x0D, 0x0A,
+                0x00, 0x0D, 0x0A,
+                0x51, 0x55, 0x49, 0x54,
+                0x0A
+        };
+
+        private boolean sentHeader;
+
+        @Override
+        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+            if (sentHeader || !(msg instanceof DatagramPacket)) {
+                ctx.write(msg, promise);
+                return;
+            }
+
+            sentHeader = true;
+
+            DatagramPacket packet = (DatagramPacket) msg;
+            ByteBuf header = proxyProtocolHeader(
+                    ctx.alloc(),
+                    FAKE,
+                    packet.recipient()
+            );
+
+            ByteBuf content = ctx.alloc().buffer(
+                    header.readableBytes() + packet.content().readableBytes()
+            );
+
+            try {
+                content.writeBytes(header);
+                content.writeBytes(
+                        packet.content(),
+                        packet.content().readerIndex(),
+                        packet.content().readableBytes()
+                );
+
+                ctx.write(new DatagramPacket(content, packet.recipient()), promise);
+            } catch (Throwable throwable) {
+                content.release();
+                promise.setFailure(throwable);
+            } finally {
+                header.release();
+                ReferenceCountUtil.release(packet);
+            }
+        }
+
+        private static ByteBuf proxyProtocolHeader(ByteBufAllocator alloc,
+                                                   InetSocketAddress source,
+                                                   InetSocketAddress destination) {
+            byte[] sourceAddress = source.getAddress().getAddress();
+            byte[] destinationAddress = destination.getAddress().getAddress();
+            if (sourceAddress.length != 4 || destinationAddress.length != 4) {
+                throw new IllegalArgumentException("This test only supports IPv4 addresses");
+            }
+
+            ByteBuf buf = alloc.buffer(28);
+            buf.writeBytes(PROXY_V2_SIGNATURE);
+            buf.writeByte(0x21);
+            buf.writeByte(0x12);
+            buf.writeShort(12);
+            buf.writeBytes(sourceAddress);
+            buf.writeBytes(destinationAddress);
+            buf.writeShort(source.getPort());
+            buf.writeShort(destination.getPort());
+            return buf;
+        }
+    }
+}

--- a/transport-raknet/src/test/java/org/cloudburstmc/netty/RakThrottleTests.java
+++ b/transport-raknet/src/test/java/org/cloudburstmc/netty/RakThrottleTests.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2025 CloudburstMC
+ *
+ * CloudburstMC licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.cloudburstmc.netty;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.*;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+import org.cloudburstmc.netty.channel.raknet.RakChannelFactory;
+import org.cloudburstmc.netty.channel.raknet.RakClientChannel;
+import org.cloudburstmc.netty.channel.raknet.config.DefaultRakServerThrottle;
+import org.cloudburstmc.netty.channel.raknet.config.RakChannelOption;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
+public class RakThrottleTests {
+
+    private static final int PORT = 19134;
+    private static final int PROTOCOL_VERSION = 11;
+
+    private EventLoopGroup group;
+    private Channel serverChannel;
+
+    @BeforeEach
+    public void setup() {
+        group = new NioEventLoopGroup();
+    }
+
+    @AfterEach
+    public void teardown() {
+        if (serverChannel != null) {
+            serverChannel.close().awaitUninterruptibly();
+        }
+        group.shutdownGracefully().awaitUninterruptibly();
+    }
+
+    private void setupServer() {
+        ServerBootstrap b = new ServerBootstrap()
+                .channelFactory(RakChannelFactory.server(NioDatagramChannel.class))
+                .group(group)
+                .option(RakChannelOption.RAK_THROTTLE, new DefaultRakServerThrottle(3, 1_000, 1))
+                .childHandler(new ChannelInitializer<Channel>() {
+                    @Override
+                    protected void initChannel(Channel ch) {
+                    }
+                });
+
+        this.serverChannel = b.bind(new InetSocketAddress(PORT)).awaitUninterruptibly().channel();
+    }
+
+    private Bootstrap clientBootstrap() {
+        return new Bootstrap()
+                .channelFactory(RakChannelFactory.client(NioDatagramChannel.class))
+                .group(group)
+                .option(RakChannelOption.RAK_PROTOCOL_VERSION, PROTOCOL_VERSION)
+                .handler(new ChannelInitializer<RakClientChannel>() {
+                    @Override
+                    protected void initChannel(RakClientChannel ch) {
+                    }
+                });
+    }
+
+    @Test
+    public void testConnectsMax() {
+        setupServer();
+
+        for (int i = 0; i < 2; i++) {
+            Channel client = clientBootstrap()
+                    .connect(new InetSocketAddress("127.0.0.1", PORT))
+                    .awaitUninterruptibly()
+                    .channel();
+            Assertions.assertEquals(i < 1, client.isActive());
+        }
+
+        try {
+            Thread.sleep(1_000);
+        } catch (InterruptedException ignored) {
+        }
+
+        for (int i = 0; i < 2; i++) {
+            Channel client = clientBootstrap()
+                    .connect(new InetSocketAddress("127.0.0.1", PORT))
+                    .awaitUninterruptibly()
+                    .channel();
+            Assertions.assertEquals(i < 1, client.isActive());
+        }
+    }
+
+    @Test
+    public void testConnectionsMax() {
+        setupServer();
+
+        List<Channel> clients = new ArrayList<>();
+        for (int i = 0; i < 4; i++) {
+            Channel client = clientBootstrap()
+                    .connect(new InetSocketAddress("127.0.0.1", PORT))
+                    .awaitUninterruptibly()
+                    .channel();
+            clients.add(client);
+            Assertions.assertEquals(i < 3, client.isActive());
+
+            try {
+                Thread.sleep(1_000);
+            } catch (InterruptedException ignored) {
+            }
+        }
+
+        for (Channel client : clients) {
+            client.close().awaitUninterruptibly();
+        }
+        clients.clear();
+
+        try {
+            Thread.sleep(10_000);
+        } catch (InterruptedException ignored) {
+        }
+
+        for (int i = 0; i < 4; i++) {
+            Channel client = clientBootstrap()
+                    .connect(new InetSocketAddress("127.0.0.1", PORT))
+                    .awaitUninterruptibly()
+                    .channel();
+            Assertions.assertEquals(i < 3, client.isActive());
+
+            try {
+                Thread.sleep(1_000);
+            } catch (InterruptedException ignored) {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Initial draft of moving Geyser Proxy protocol handling into the RakNet codec, emitting the original/client ip and using that for rate limiting but still route to the proxy ip.