### PR TITLE
Add reusable feature snapshot publishing

### DIFF
--- a/.github/workflows/deploy-feature-snapshot.yml
+++ b/.github/workflows/deploy-feature-snapshot.yml
@@ -26,7 +26,13 @@ jobs:
           feature_name="${GITHUB_REF_NAME#feature-snapshot/}"
           feature_name="${feature_name//\//-}"
           feature_name="${feature_name//[^A-Za-z0-9._-]/-}"
+          # Keep this as a Maven snapshot. The snapshot repository will publish
+          # timestamped concrete artifacts, matching the normal develop flow.
           publish_version="${base_version}-${feature_name}-SNAPSHOT"
+          if [[ "${publish_version}" != *-SNAPSHOT ]]; then
+            echo "::error::Feature publishes must use Maven snapshot versions"
+            exit 1
+          fi
 
           echo "publish-version=${publish_version}" >> "$GITHUB_OUTPUT"
           echo "Publishing ${publish_version}"

--- a/.github/workflows/deploy-feature-snapshot.yml
+++ b/.github/workflows/deploy-feature-snapshot.yml
@@ -1,0 +1,44 @@
+name: Deploy Feature Snapshot
+
+on:
+  push:
+    branches:
+      - 'feature-snapshot/**'
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      publish-version: ${{ steps.version.outputs.publish-version }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Compute feature snapshot version
+        id: version
+        shell: bash
+        run: |
+          base_version="$(sed -n 's/^version=//p' gradle.properties)"
+          base_version="${base_version%-SNAPSHOT}"
+          if [ -z "$base_version" ]; then
+            echo "::error::Could not read project version from gradle.properties"
+            exit 1
+          fi
+
+          feature_name="${GITHUB_REF_NAME#feature-snapshot/}"
+          feature_name="${feature_name//\//-}"
+          feature_name="${feature_name//[^A-Za-z0-9._-]/-}"
+          publish_version="${base_version}-${feature_name}-SNAPSHOT"
+
+          echo "publish-version=${publish_version}" >> "$GITHUB_OUTPUT"
+          echo "Publishing ${publish_version}"
+
+  deploy:
+    needs: version
+    uses: ./.github/workflows/deploy.yml
+    with:
+      deploy-url: "https://repo.opencollab.dev/maven-snapshots/"
+      publish-version: ${{ needs.version.outputs.publish-version }}
+    secrets:
+      DEPLOY_USERNAME: ${{ secrets.OPENCOLLAB_USERNAME }}
+      DEPLOY_PASSWORD: ${{ secrets.OPENCOLLAB_PASSWORD }}
+      PGP_SECRET: ${{ secrets.MAVEN_CENTRAL_SECRET }}
+      PGP_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_PASSPHRASE }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,11 @@ on:
         description: 'The maven repository to deploy to'
         required: true
         type: string
+      publish-version:
+        description: 'Optional Maven project version override'
+        required: false
+        default: ''
+        type: string
     secrets:
       DEPLOY_USERNAME:
         required: true
@@ -37,3 +42,4 @@ jobs:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           MAVEN_DEPLOY_URL: ${{ inputs.deploy-url }}
+          NETWORK_PUBLISH_VERSION: ${{ inputs.publish-version }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
         required: true
         type: string
       publish-version:
-        description: 'Optional Maven project version override'
+        description: 'Optional Maven project version override. Use a -SNAPSHOT value to keep Maven timestamped snapshot publishing.'
         required: false
         default: ''
         type: string

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,13 +14,18 @@
  * under the License.
  */
 
+val networkVersion = System.getenv("NETWORK_PUBLISH_VERSION")
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+        ?: rootProject.property("version") as String
+
 subprojects {
     apply(plugin = "java-library")
     apply(plugin = "maven-publish")
     apply(plugin = "signing")
 
     group = "org.cloudburstmc.netty"
-    version = rootProject.property("version") as String
+    version = networkVersion
 
     repositories {
         mavenLocal()


### PR DESCRIPTION
## Summary

Adds a reusable feature-snapshot publishing path for Network without tying it to a specific feature branch.

- Adds a `Deploy Feature Snapshot` workflow triggered by pushes to `feature-snapshot/**` branches.
- Derives the Maven version from `gradle.properties` plus the feature branch suffix, for example `feature-snapshot/bedrock-guard` publishes `1.0.0.CR3-bedrock-guard-SNAPSHOT`.
- Extends the shared deploy workflow with an optional `publish-version` input, passed through as `NETWORK_PUBLISH_VERSION`.
- Keeps normal `develop` snapshot publishing behavior unchanged when no override is supplied.

## Validation

- `./gradlew :transport-raknet:test`
- `NETWORK_PUBLISH_VERSION=1.0.0.CR3-bedrock-guard-SNAPSHOT ./gradlew :transport-raknet:publishToMavenLocal`
- Confirmed local artifact path: `/home/zed/.m2/repository/org/cloudburstmc/netty/netty-transport-raknet/1.0.0.CR3-bedrock-guard-SNAPSHOT`

## Notes

This is intentionally separate from the Bedrock guard integration branch so publishing infrastructure can be reviewed independently.