### PR TITLE
Preserve local address for unconnected ping/pong

### DIFF
--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakPing.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakPing.java
@@ -24,10 +24,16 @@ public class RakPing {
 
     private final long pingTime;
     private final InetSocketAddress sender;
+    private final InetSocketAddress recipient;
 
     public RakPing(long pingTime, InetSocketAddress sender) {
+        this(pingTime, sender, null);
+    }
+
+    public RakPing(long pingTime, InetSocketAddress sender, InetSocketAddress recipient) {
         this.pingTime = pingTime;
         this.sender = sender;
+        this.recipient = recipient;
     }
 
     public long getPingTime() {
@@ -39,7 +45,11 @@ public class RakPing {
         return this.sender;
     }
 
+    public InetSocketAddress getRecipient() {
+        return this.recipient;
+    }
+
     public RakPong reply(long guid, ByteBuf pongData) {
-        return new RakPong(this.pingTime, guid, pongData, this.sender);
+        return new RakPong(this.pingTime, guid, pongData, this.sender, this.recipient);
     }
 }

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakPong.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/channel/raknet/RakPong.java
@@ -28,12 +28,18 @@ public class RakPong extends AbstractReferenceCounted {
     private final long guid;
     private final ByteBuf pongData;
     private final InetSocketAddress sender;
+    private final InetSocketAddress recipient;
 
     public RakPong(long pingTime, long guid, ByteBuf pongData, InetSocketAddress sender) {
+        this(pingTime, guid, pongData, sender, null);
+    }
+
+    public RakPong(long pingTime, long guid, ByteBuf pongData, InetSocketAddress sender, InetSocketAddress recipient) {
         this.pingTime = pingTime;
         this.guid = guid;
         this.pongData = pongData;
         this.sender = sender;
+        this.recipient = recipient;
     }
 
     public long getPingTime() {
@@ -50,6 +56,10 @@ public class RakPong extends AbstractReferenceCounted {
 
     public InetSocketAddress getSender() {
         return this.sender;
+    }
+
+    public InetSocketAddress getRecipient() {
+        return this.recipient;
     }
 
     @Override

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/common/UnconnectedPingEncoder.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/common/UnconnectedPingEncoder.java
@@ -52,6 +52,6 @@ public class UnconnectedPingEncoder extends ChannelOutboundHandlerAdapter {
         pingBuffer.writeLong(ping.getPingTime());
         pingBuffer.writeBytes(magicBuf, magicBuf.readerIndex(), magicBuf.readableBytes());
         pingBuffer.writeLong(guid);
-        ctx.write(new DatagramPacket(pingBuffer, ping.getSender()), promise);
+        ctx.write(new DatagramPacket(pingBuffer, ping.getSender(), ping.getRecipient()), promise);
     }
 }

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/common/UnconnectedPongDecoder.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/common/UnconnectedPongDecoder.java
@@ -66,6 +66,6 @@ public class UnconnectedPongDecoder extends AdvancedChannelInboundHandler<Datagr
         if (buf.isReadable(2)) { // Length
             pongData = buf.readRetainedSlice(buf.readUnsignedShort());
         }
-        ctx.fireChannelRead(new RakPong(pingTime, guid, pongData, packet.sender()));
+        ctx.fireChannelRead(new RakPong(pingTime, guid, pongData, packet.sender(), packet.recipient()));
     }
 }

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/common/UnconnectedPongEncoder.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/common/UnconnectedPongEncoder.java
@@ -54,6 +54,6 @@ public class UnconnectedPongEncoder extends ChannelOutboundHandlerAdapter {
         pongBuffer.writeBytes(magicBuf, magicBuf.readerIndex(), magicBuf.readableBytes());
         pongBuffer.writeShort(pongData.readableBytes());
         pongBuffer.writeBytes(pongData, pongData.readerIndex(), pongData.readableBytes());
-        ctx.write(new DatagramPacket(pongBuffer, pong.getSender()), promise);
+        ctx.write(new DatagramPacket(pongBuffer, pong.getSender(), pong.getRecipient()), promise);
     }
 }

--- a/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/server/RakServerOfflineHandler.java
+++ b/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/server/RakServerOfflineHandler.java
@@ -112,7 +112,7 @@ public class RakServerOfflineHandler extends AdvancedChannelInboundHandler<Datag
 
         boolean handlePing = ((RakServerChannelConfig) ctx.channel().config()).getHandlePing();
         if (handlePing) {
-            ctx.fireChannelRead(new RakPing(pingTime, packet.sender()));
+            ctx.fireChannelRead(new RakPing(pingTime, packet.sender(), packet.recipient()));
             return;
         }
 


### PR DESCRIPTION
## Summary

Propagates the local (recipient) address through `RakPing` and `RakPong` so that unconnected ping/pong packets are sent from the same local address the request arrived on. This makes the manual ping-handling path and the client-sent ping path consistent with the behaviour already used for connected child-channel data (`RakChildDatagramHandler`) and automatic replies (`RakUtils.datagramReply`).

On multi-homed hosts or wildcard binds (`0.0.0.0`), the source address of outgoing datagrams was previously left to the OS, so a pong could be sent from a different local address than the one that received the ping. This is problematic for setups behind HAProxy / multiple interfaces.

## Changes

- `RakPing` / `RakPong`: add a `recipient` (local) address field, getter, and constructor parameter; `reply()` carries it through to the pong.
- `RakServerOfflineHandler`: populate `RakPing` with `packet.recipient()` when handing a manually handled ping to the user pipeline.
- `UnconnectedPongEncoder`: send the pong from `pong.getRecipient()` (source), matching `RakUtils.datagramReply`.
- `UnconnectedPingEncoder`: send the client ping from `ping.getRecipient()` (source) when provided.
- `UnconnectedPongDecoder`: expose the receiving local address on the decoded `RakPong` (`packet.recipient()`).

## Backwards compatibility

Fully backwards compatible. The existing `RakPing(long, InetSocketAddress)` and `RakPong(long, long, ByteBuf, InetSocketAddress)` constructors are kept and delegate to the new variants with `recipient = null`, in which case the OS selects the source address exactly as before.